### PR TITLE
feat: add DynStop — Arc-based cloneable type-erased Stop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"
@@ -25,8 +25,8 @@ keywords = ["cancellation", "cooperative", "async", "ffi", "no_std"]
 categories = ["concurrency", "no-std", "rust-patterns"]
 
 [workspace.dependencies]
-enough = { version = "0.4.1", path = "crates/enough", features = ["std"] }
-almost-enough = { version = "0.4.1", path = "crates/almost-enough", features = ["std"] }
+enough = { version = "0.4.2", path = "crates/enough", features = ["std"] }
+almost-enough = { version = "0.4.2", path = "crates/almost-enough", features = ["std"] }
 # enough-tokio and enough-ffi have independent versioning
 enough-tokio = { path = "crates/enough-tokio" }
 enough-ffi = { path = "crates/enough-ffi" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,9 @@ keywords = ["cancellation", "cooperative", "async", "ffi", "no_std"]
 categories = ["concurrency", "no-std", "rust-patterns"]
 
 [workspace.dependencies]
-enough = { version = "0.4.2", path = "crates/enough", features = ["std"] }
+enough = { version = "0.4.2", path = "crates/enough", default-features = false }
 almost-enough = { version = "0.4.2", path = "crates/almost-enough", features = ["std"] }
+zenbench = { git = "https://github.com/imazen/zenbench.git" }
 # enough-tokio and enough-ffi have independent versioning
 enough-tokio = { path = "crates/enough-tokio" }
 enough-ffi = { path = "crates/enough-ffi" }

--- a/crates/almost-enough/Cargo.toml
+++ b/crates/almost-enough/Cargo.toml
@@ -15,11 +15,11 @@ alloc = []
 std = ["alloc"]
 
 [dependencies]
-enough = { version = "0.4.2", path = "../enough", default-features = false }
+enough = { workspace = true, default-features = false }
 
 [dev-dependencies]
 criterion = { version = "0.5", default-features = false }
-zenbench = { git = "https://github.com/imazen/zenbench.git" }
+zenbench = { workspace = true }
 
 [[bench]]
 name = "stop_check"

--- a/crates/almost-enough/Cargo.toml
+++ b/crates/almost-enough/Cargo.toml
@@ -19,7 +19,12 @@ enough = { version = "0.4.2", path = "../enough", default-features = false }
 
 [dev-dependencies]
 criterion = { version = "0.5", default-features = false }
+zenbench = { git = "https://github.com/imazen/zenbench.git" }
 
 [[bench]]
 name = "stop_check"
+harness = false
+
+[[bench]]
+name = "stop_check_zen"
 harness = false

--- a/crates/almost-enough/Cargo.toml
+++ b/crates/almost-enough/Cargo.toml
@@ -15,7 +15,7 @@ alloc = []
 std = ["alloc"]
 
 [dependencies]
-enough = { version = "0.4.1", path = "../enough", default-features = false }
+enough = { version = "0.4.2", path = "../enough", default-features = false }
 
 [dev-dependencies]
 criterion = { version = "0.5", default-features = false }

--- a/crates/almost-enough/benches/stop_check.rs
+++ b/crates/almost-enough/benches/stop_check.rs
@@ -2,8 +2,8 @@ use std::hint::black_box;
 use std::time::Duration;
 
 use almost_enough::{
-    ChildStopper, FnStop, OrStop, Stop, StopExt, StopSource, Stopper, SyncStopper, TimeoutExt,
-    Unstoppable, WithTimeout,
+    BoxedStop, ChildStopper, DynStop, FnStop, OrStop, Stop, StopExt, StopSource, Stopper,
+    SyncStopper, TimeoutExt, Unstoppable, WithTimeout,
 };
 use criterion::{Criterion, criterion_group, criterion_main};
 
@@ -61,6 +61,18 @@ fn bench_check(c: &mut Criterion) {
         b.iter(|| black_box(&stop).check())
     });
 
+    // DynStop wrapping Unstoppable
+    g.bench_function("dyn_unstoppable", |b| {
+        let stop = Unstoppable.into_dyn();
+        b.iter(|| black_box(&stop).check())
+    });
+
+    // DynStop wrapping Stopper
+    g.bench_function("dyn_stopper", |b| {
+        let stop = Stopper::new().into_dyn();
+        b.iter(|| black_box(&stop).check())
+    });
+
     // WithTimeout<StopRef> (inner check + Instant::now())
     g.bench_function("with_timeout", |b| {
         let source = StopSource::new();
@@ -101,7 +113,7 @@ fn bench_check(c: &mut Criterion) {
     g.finish();
 }
 
-// ── Group: dispatch (generic vs dynamic) ────────────────────────────
+// ── Group: dispatch (generic vs dyn vs BoxedStop vs DynStop) ─────────
 
 #[inline(never)]
 fn check_generic(stop: &impl Stop) -> Result<(), almost_enough::StopReason> {
@@ -113,9 +125,20 @@ fn check_dyn(stop: &dyn Stop) -> Result<(), almost_enough::StopReason> {
     stop.check()
 }
 
+#[inline(never)]
+fn check_boxed(stop: &BoxedStop) -> Result<(), almost_enough::StopReason> {
+    stop.check()
+}
+
+#[inline(never)]
+fn check_dyn_stop(stop: &DynStop) -> Result<(), almost_enough::StopReason> {
+    stop.check()
+}
+
 fn bench_dispatch(c: &mut Criterion) {
     let mut g = c.benchmark_group("dispatch");
 
+    // Unstoppable through every path
     g.bench_function("unstoppable_generic", |b| {
         let stop = Unstoppable;
         b.iter(|| check_generic(black_box(&stop)))
@@ -126,6 +149,17 @@ fn bench_dispatch(c: &mut Criterion) {
         b.iter(|| check_dyn(black_box(&stop)))
     });
 
+    g.bench_function("unstoppable_boxed", |b| {
+        let stop = Unstoppable.into_boxed();
+        b.iter(|| check_boxed(black_box(&stop)))
+    });
+
+    g.bench_function("unstoppable_dynstop", |b| {
+        let stop = Unstoppable.into_dyn();
+        b.iter(|| check_dyn_stop(black_box(&stop)))
+    });
+
+    // Stopper through every path
     g.bench_function("stopper_generic", |b| {
         let stop = Stopper::new();
         b.iter(|| check_generic(black_box(&stop)))
@@ -134,6 +168,239 @@ fn bench_dispatch(c: &mut Criterion) {
     g.bench_function("stopper_dyn", |b| {
         let stop = Stopper::new();
         b.iter(|| check_dyn(black_box(&stop)))
+    });
+
+    g.bench_function("stopper_boxed", |b| {
+        let stop = Stopper::new().into_boxed();
+        b.iter(|| check_boxed(black_box(&stop)))
+    });
+
+    g.bench_function("stopper_dynstop", |b| {
+        let stop = Stopper::new().into_dyn();
+        b.iter(|| check_dyn_stop(black_box(&stop)))
+    });
+
+    // DynStop behind &dyn Stop (double dispatch)
+    g.bench_function("stopper_dynstop_as_dyn", |b| {
+        let stop = Stopper::new().into_dyn();
+        b.iter(|| check_dyn(black_box(&stop) as &dyn Stop))
+    });
+
+    // BoxedStop behind &dyn Stop (double dispatch)
+    g.bench_function("stopper_boxed_as_dyn", |b| {
+        let stop = Stopper::new().into_boxed();
+        b.iter(|| check_dyn(black_box(&stop) as &dyn Stop))
+    });
+
+    g.finish();
+}
+
+// ── Group: may_stop + active_stop optimization patterns ──────────────
+
+#[inline(never)]
+fn check_dyn_may_stop(stop: &dyn Stop) -> Result<(), almost_enough::StopReason> {
+    let stop = stop.may_stop().then_some(stop);
+    stop.check()
+}
+
+#[inline(never)]
+fn check_boxed_active(stop: &BoxedStop) -> Result<(), almost_enough::StopReason> {
+    let stop = stop.active_stop();
+    stop.check()
+}
+
+#[inline(never)]
+fn check_dynstop_active(stop: &DynStop) -> Result<(), almost_enough::StopReason> {
+    let stop = stop.active_stop();
+    stop.check()
+}
+
+fn bench_optimization(c: &mut Criterion) {
+    let mut g = c.benchmark_group("optimization");
+
+    // Unstoppable: may_stop pattern should eliminate check
+    g.bench_function("unstoppable_dyn_raw", |b| {
+        let stop = Unstoppable;
+        b.iter(|| check_dyn(black_box(&stop)))
+    });
+
+    g.bench_function("unstoppable_dyn_may_stop", |b| {
+        let stop = Unstoppable;
+        b.iter(|| check_dyn_may_stop(black_box(&stop)))
+    });
+
+    // BoxedStop(Unstoppable): active_stop should collapse to None
+    g.bench_function("boxed_unstoppable_raw", |b| {
+        let stop = Unstoppable.into_boxed();
+        b.iter(|| check_boxed(black_box(&stop)))
+    });
+
+    g.bench_function("boxed_unstoppable_active", |b| {
+        let stop = Unstoppable.into_boxed();
+        b.iter(|| check_boxed_active(black_box(&stop)))
+    });
+
+    // DynStop(Unstoppable): active_stop should collapse to None
+    g.bench_function("dyn_unstoppable_raw", |b| {
+        let stop = Unstoppable.into_dyn();
+        b.iter(|| check_dyn_stop(black_box(&stop)))
+    });
+
+    g.bench_function("dyn_unstoppable_active", |b| {
+        let stop = Unstoppable.into_dyn();
+        b.iter(|| check_dynstop_active(black_box(&stop)))
+    });
+
+    // Stopper: active_stop collapses one dispatch layer
+    g.bench_function("boxed_stopper_raw", |b| {
+        let stop = Stopper::new().into_boxed();
+        b.iter(|| check_boxed(black_box(&stop)))
+    });
+
+    g.bench_function("boxed_stopper_active", |b| {
+        let stop = Stopper::new().into_boxed();
+        b.iter(|| check_boxed_active(black_box(&stop)))
+    });
+
+    g.bench_function("dyn_stopper_raw", |b| {
+        let stop = Stopper::new().into_dyn();
+        b.iter(|| check_dyn_stop(black_box(&stop)))
+    });
+
+    g.bench_function("dyn_stopper_active", |b| {
+        let stop = Stopper::new().into_dyn();
+        b.iter(|| check_dynstop_active(black_box(&stop)))
+    });
+
+    g.finish();
+}
+
+// ── Group: hot loops (realistic workload with periodic checks) ───────
+
+const HOT_LOOP_ITERS: usize = 10_000;
+const CHECK_INTERVAL: usize = 64;
+
+/// Trivial work unit to prevent loop elimination
+#[inline(always)]
+fn trivial_work(i: usize) -> usize {
+    black_box(i.wrapping_mul(2654435761))
+}
+
+#[inline(never)]
+fn hot_loop_generic(stop: &impl Stop) -> usize {
+    let mut acc = 0usize;
+    for i in 0..HOT_LOOP_ITERS {
+        if i % CHECK_INTERVAL == 0 {
+            let _ = stop.check();
+        }
+        acc = acc.wrapping_add(trivial_work(i));
+    }
+    acc
+}
+
+#[inline(never)]
+fn hot_loop_dyn(stop: &dyn Stop) -> usize {
+    let mut acc = 0usize;
+    for i in 0..HOT_LOOP_ITERS {
+        if i % CHECK_INTERVAL == 0 {
+            let _ = stop.check();
+        }
+        acc = acc.wrapping_add(trivial_work(i));
+    }
+    acc
+}
+
+#[inline(never)]
+fn hot_loop_dyn_may_stop(stop: &dyn Stop) -> usize {
+    let stop = stop.may_stop().then_some(stop);
+    let mut acc = 0usize;
+    for i in 0..HOT_LOOP_ITERS {
+        if i % CHECK_INTERVAL == 0 {
+            let _ = stop.check();
+        }
+        acc = acc.wrapping_add(trivial_work(i));
+    }
+    acc
+}
+
+#[inline(never)]
+fn hot_loop_boxed_active(stop: &BoxedStop) -> usize {
+    let stop = stop.active_stop();
+    let mut acc = 0usize;
+    for i in 0..HOT_LOOP_ITERS {
+        if i % CHECK_INTERVAL == 0 {
+            let _ = stop.check();
+        }
+        acc = acc.wrapping_add(trivial_work(i));
+    }
+    acc
+}
+
+#[inline(never)]
+fn hot_loop_dynstop_active(stop: &DynStop) -> usize {
+    let stop = stop.active_stop();
+    let mut acc = 0usize;
+    for i in 0..HOT_LOOP_ITERS {
+        if i % CHECK_INTERVAL == 0 {
+            let _ = stop.check();
+        }
+        acc = acc.wrapping_add(trivial_work(i));
+    }
+    acc
+}
+
+fn bench_hot_loop(c: &mut Criterion) {
+    let mut g = c.benchmark_group("hot_loop");
+
+    // Unstoppable through various dispatch paths
+    g.bench_function("unstoppable_generic", |b| {
+        b.iter(|| hot_loop_generic(&Unstoppable))
+    });
+
+    g.bench_function("unstoppable_dyn", |b| {
+        let stop = Unstoppable;
+        b.iter(|| hot_loop_dyn(&stop))
+    });
+
+    g.bench_function("unstoppable_dyn_may_stop", |b| {
+        let stop = Unstoppable;
+        b.iter(|| hot_loop_dyn_may_stop(&stop))
+    });
+
+    g.bench_function("unstoppable_boxed_active", |b| {
+        let stop = Unstoppable.into_boxed();
+        b.iter(|| hot_loop_boxed_active(&stop))
+    });
+
+    g.bench_function("unstoppable_dynstop_active", |b| {
+        let stop = Unstoppable.into_dyn();
+        b.iter(|| hot_loop_dynstop_active(&stop))
+    });
+
+    // Stopper through various dispatch paths
+    g.bench_function("stopper_generic", |b| {
+        let stop = Stopper::new();
+        b.iter(|| hot_loop_generic(&stop))
+    });
+
+    g.bench_function("stopper_dyn", |b| {
+        let stop = Stopper::new();
+        b.iter(|| hot_loop_dyn(&stop))
+    });
+
+    g.bench_function("stopper_dyn_may_stop", |b| {
+        let stop = Stopper::new();
+        b.iter(|| hot_loop_dyn_may_stop(&stop))
+    });
+
+    g.bench_function("stopper_boxed", |b| {
+        let stop = Stopper::new().into_boxed();
+        b.iter(|| hot_loop_boxed_active(&stop))
+    });
+
+    g.bench_function("stopper_dynstop", |b| {
+        let stop = Stopper::new().into_dyn();
+        b.iter(|| hot_loop_dynstop_active(&stop))
     });
 
     g.finish();
@@ -157,5 +424,12 @@ fn bench_check_cancelled(c: &mut Criterion) {
     g.finish();
 }
 
-criterion_group!(benches, bench_check, bench_dispatch, bench_check_cancelled);
+criterion_group!(
+    benches,
+    bench_check,
+    bench_dispatch,
+    bench_optimization,
+    bench_hot_loop,
+    bench_check_cancelled
+);
 criterion_main!(benches);

--- a/crates/almost-enough/benches/stop_check_zen.rs
+++ b/crates/almost-enough/benches/stop_check_zen.rs
@@ -50,7 +50,7 @@ fn main() {
         suite.compare("per_call_cost", |group| {
             group
                 .config()
-                .rounds(200)
+                .max_rounds(200)
                 .cache_firewall(false)
                 .sort_by_speed(true);
             group.throughput(zenbench::Throughput::Elements(100));
@@ -219,7 +219,7 @@ fn main() {
         suite.compare("hot_loop_unstoppable", |group| {
             group
                 .config()
-                .rounds(100)
+                .max_rounds(100)
                 .cache_firewall(false)
                 .sort_by_speed(true);
             group.baseline("generic");
@@ -261,7 +261,7 @@ fn main() {
         suite.compare("hot_loop_stopper", |group| {
             group
                 .config()
-                .rounds(100)
+                .max_rounds(100)
                 .cache_firewall(false)
                 .sort_by_speed(true);
             group.baseline("generic");
@@ -305,7 +305,7 @@ fn main() {
         // ═══════════════════════════════════════════════════════════
 
         suite.compare("check_cancelled", |group| {
-            group.config().rounds(200).cache_firewall(false);
+            group.config().max_rounds(200).cache_firewall(false);
 
             group.bench("Stopper", |b| {
                 let stop = Stopper::cancelled();
@@ -321,7 +321,7 @@ fn main() {
         suite.compare("cold_cache_stopper", |group| {
             group
                 .config()
-                .rounds(100)
+                .max_rounds(100)
                 .cache_firewall(true)
                 .sort_by_speed(true);
             group.baseline("&dyn Stop");

--- a/crates/almost-enough/benches/stop_check_zen.rs
+++ b/crates/almost-enough/benches/stop_check_zen.rs
@@ -52,69 +52,22 @@ fn check_dynstop_active(stop: &DynStop) -> Result<(), almost_enough::StopReason>
     stop.check()
 }
 
-// ── Helpers: hot loop variants ──────────────────────────────────────
+// ── Hot loop macro ──────────────────────────────────────────────────
+// Inlined into each benchmark closure so the compiler sees the full
+// picture — exactly like real code. No #[inline(never)] boundary.
 
-#[inline(never)]
-fn hot_loop_generic(stop: &impl Stop) -> usize {
-    let mut acc = 0usize;
-    for i in 0..HOT_LOOP_ITERS {
-        if i % CHECK_INTERVAL == 0 {
-            let _ = stop.check();
+macro_rules! hot_loop {
+    ($stop:expr) => {{
+        let stop = $stop;
+        let mut acc = 0usize;
+        for i in 0..HOT_LOOP_ITERS {
+            if i % CHECK_INTERVAL == 0 {
+                let _ = stop.check();
+            }
+            acc = acc.wrapping_add(trivial_work(i));
         }
-        acc = acc.wrapping_add(trivial_work(i));
-    }
-    acc
-}
-
-#[inline(never)]
-fn hot_loop_dyn(stop: &dyn Stop) -> usize {
-    let mut acc = 0usize;
-    for i in 0..HOT_LOOP_ITERS {
-        if i % CHECK_INTERVAL == 0 {
-            let _ = stop.check();
-        }
-        acc = acc.wrapping_add(trivial_work(i));
-    }
-    acc
-}
-
-#[inline(never)]
-fn hot_loop_dyn_may_stop(stop: &dyn Stop) -> usize {
-    let stop = stop.may_stop().then_some(stop);
-    let mut acc = 0usize;
-    for i in 0..HOT_LOOP_ITERS {
-        if i % CHECK_INTERVAL == 0 {
-            let _ = stop.check();
-        }
-        acc = acc.wrapping_add(trivial_work(i));
-    }
-    acc
-}
-
-#[inline(never)]
-fn hot_loop_boxed_active(stop: &BoxedStop) -> usize {
-    let stop = stop.active_stop();
-    let mut acc = 0usize;
-    for i in 0..HOT_LOOP_ITERS {
-        if i % CHECK_INTERVAL == 0 {
-            let _ = stop.check();
-        }
-        acc = acc.wrapping_add(trivial_work(i));
-    }
-    acc
-}
-
-#[inline(never)]
-fn hot_loop_dynstop_active(stop: &DynStop) -> usize {
-    let stop = stop.active_stop();
-    let mut acc = 0usize;
-    for i in 0..HOT_LOOP_ITERS {
-        if i % CHECK_INTERVAL == 0 {
-            let _ = stop.check();
-        }
-        acc = acc.wrapping_add(trivial_work(i));
-    }
-    acc
+        zenbench::black_box(acc)
+    }};
 }
 
 /// Run check() 100 times to lift measurement above timer resolution.
@@ -526,26 +479,34 @@ fn main() {
             group.config().rounds(100).cache_firewall(false).sort_by_speed(true);
             group.baseline("generic");
 
-            group.bench("generic", |b| b.iter(|| hot_loop_generic(&Unstoppable)));
-
-            group.bench("dyn", |b| {
+            group.bench("generic", |b| {
                 let stop = Unstoppable;
-                b.iter(|| hot_loop_dyn(&stop))
+                b.iter(|| hot_loop!(zenbench::black_box(&stop)))
             });
 
-            group.bench("dyn_may_stop", |b| {
+            group.bench("&dyn Stop", |b| {
                 let stop = Unstoppable;
-                b.iter(|| hot_loop_dyn_may_stop(&stop))
+                let stop: &dyn Stop = &stop;
+                b.iter(|| hot_loop!(zenbench::black_box(stop)))
             });
 
-            group.bench("boxed_active", |b| {
+            group.bench("&dyn Stop + may_stop", |b| {
+                let stop = Unstoppable;
+                let stop: &dyn Stop = &stop;
+                let stop = stop.may_stop().then_some(stop);
+                b.iter(|| hot_loop!(zenbench::black_box(&stop)))
+            });
+
+            group.bench("BoxedStop.active_stop", |b| {
                 let stop = Unstoppable.into_boxed();
-                b.iter(|| hot_loop_boxed_active(&stop))
+                let stop = stop.active_stop();
+                b.iter(|| hot_loop!(zenbench::black_box(&stop)))
             });
 
-            group.bench("dynstop_active", |b| {
+            group.bench("DynStop.active_stop", |b| {
                 let stop = Unstoppable.into_dyn();
-                b.iter(|| hot_loop_dynstop_active(&stop))
+                let stop = stop.active_stop();
+                b.iter(|| hot_loop!(zenbench::black_box(&stop)))
             });
         });
 
@@ -555,27 +516,32 @@ fn main() {
 
             group.bench("generic", |b| {
                 let stop = Stopper::new();
-                b.iter(|| hot_loop_generic(&stop))
+                b.iter(|| hot_loop!(zenbench::black_box(&stop)))
             });
 
-            group.bench("dyn", |b| {
+            group.bench("&dyn Stop", |b| {
                 let stop = Stopper::new();
-                b.iter(|| hot_loop_dyn(&stop))
+                let stop: &dyn Stop = &stop;
+                b.iter(|| hot_loop!(zenbench::black_box(stop)))
             });
 
-            group.bench("dyn_may_stop", |b| {
+            group.bench("&dyn Stop + may_stop", |b| {
                 let stop = Stopper::new();
-                b.iter(|| hot_loop_dyn_may_stop(&stop))
+                let stop: &dyn Stop = &stop;
+                let stop = stop.may_stop().then_some(stop);
+                b.iter(|| hot_loop!(zenbench::black_box(&stop)))
             });
 
-            group.bench("boxed_active", |b| {
+            group.bench("BoxedStop.active_stop", |b| {
                 let stop = Stopper::new().into_boxed();
-                b.iter(|| hot_loop_boxed_active(&stop))
+                let stop = stop.active_stop();
+                b.iter(|| hot_loop!(zenbench::black_box(&stop)))
             });
 
-            group.bench("dynstop_active", |b| {
+            group.bench("DynStop.active_stop", |b| {
                 let stop = Stopper::new().into_dyn();
-                b.iter(|| hot_loop_dynstop_active(&stop))
+                let stop = stop.active_stop();
+                b.iter(|| hot_loop!(zenbench::black_box(&stop)))
             });
         });
 
@@ -601,21 +567,24 @@ fn main() {
 
         suite.compare("cold_cache_stopper", |group| {
             group.config().rounds(100).cache_firewall(true).sort_by_speed(true);
-            group.baseline("dyn");
+            group.baseline("&dyn Stop");
 
-            group.bench("dyn", |b| {
+            group.bench("&dyn Stop", |b| {
                 let stop = Stopper::new();
-                b.iter(|| hot_loop_dyn(&stop))
+                let stop: &dyn Stop = &stop;
+                b.iter(|| hot_loop!(zenbench::black_box(stop)))
             });
 
-            group.bench("boxed_active", |b| {
+            group.bench("BoxedStop.active_stop", |b| {
                 let stop = Stopper::new().into_boxed();
-                b.iter(|| hot_loop_boxed_active(&stop))
+                let stop = stop.active_stop();
+                b.iter(|| hot_loop!(zenbench::black_box(&stop)))
             });
 
-            group.bench("dynstop_active", |b| {
+            group.bench("DynStop.active_stop", |b| {
                 let stop = Stopper::new().into_dyn();
-                b.iter(|| hot_loop_dynstop_active(&stop))
+                let stop = stop.active_stop();
+                b.iter(|| hot_loop!(zenbench::black_box(&stop)))
             });
         });
     });

--- a/crates/almost-enough/benches/stop_check_zen.rs
+++ b/crates/almost-enough/benches/stop_check_zen.rs
@@ -5,8 +5,7 @@
 use std::time::Duration;
 
 use almost_enough::{
-    BoxedStop, ChildStopper, DynStop, FnStop, OrStop, Stop, StopExt, StopSource, Stopper,
-    SyncStopper, TimeoutExt, Unstoppable,
+    ChildStopper, OrStop, Stop, StopExt, StopSource, Stopper, SyncStopper, TimeoutExt, Unstoppable,
 };
 
 const HOT_LOOP_ITERS: usize = 10_000;
@@ -49,7 +48,11 @@ fn main() {
         // ═══════════════════════════════════════════════════════════
 
         suite.compare("per_call_cost", |group| {
-            group.config().rounds(200).cache_firewall(false).sort_by_speed(true);
+            group
+                .config()
+                .rounds(200)
+                .cache_firewall(false)
+                .sort_by_speed(true);
             group.throughput(zenbench::Throughput::Elements(100));
             group.throughput_unit("checks");
             group.baseline("impl Stop (Unstoppable)");
@@ -214,7 +217,11 @@ fn main() {
         // ═══════════════════════════════════════════════════════════
 
         suite.compare("hot_loop_unstoppable", |group| {
-            group.config().rounds(100).cache_firewall(false).sort_by_speed(true);
+            group
+                .config()
+                .rounds(100)
+                .cache_firewall(false)
+                .sort_by_speed(true);
             group.baseline("generic");
 
             group.subgroup("Zero-cost paths");
@@ -252,7 +259,11 @@ fn main() {
         });
 
         suite.compare("hot_loop_stopper", |group| {
-            group.config().rounds(100).cache_firewall(false).sort_by_speed(true);
+            group
+                .config()
+                .rounds(100)
+                .cache_firewall(false)
+                .sort_by_speed(true);
             group.baseline("generic");
 
             group.subgroup("Direct");
@@ -308,7 +319,11 @@ fn main() {
         });
 
         suite.compare("cold_cache_stopper", |group| {
-            group.config().rounds(100).cache_firewall(true).sort_by_speed(true);
+            group
+                .config()
+                .rounds(100)
+                .cache_firewall(true)
+                .sort_by_speed(true);
             group.baseline("&dyn Stop");
 
             group.bench("&dyn Stop", |b| {

--- a/crates/almost-enough/benches/stop_check_zen.rs
+++ b/crates/almost-enough/benches/stop_check_zen.rs
@@ -1,9 +1,5 @@
 //! Interleaved microbenchmarks for Stop dispatch patterns using zenbench.
 //!
-//! Unlike criterion (which runs each benchmark sequentially), zenbench
-//! interleaves samples from all benchmarks in a comparison group, ensuring
-//! each variant is measured under identical system conditions.
-//!
 //! Run with: cargo bench --bench stop_check_zen
 
 use std::time::Duration;
@@ -16,49 +12,17 @@ use almost_enough::{
 const HOT_LOOP_ITERS: usize = 10_000;
 const CHECK_INTERVAL: usize = 64;
 
-/// Trivial work unit to prevent loop elimination
 #[inline(always)]
 fn trivial_work(i: usize) -> usize {
     zenbench::black_box(i.wrapping_mul(2654435761))
 }
 
-// ── Helpers: various fn signatures ──────────────────────────────────
-
-#[inline(never)]
-fn check_generic(stop: &impl Stop) -> Result<(), almost_enough::StopReason> {
-    stop.check()
-}
-
-#[inline(never)]
-fn check_dyn(stop: &dyn Stop) -> Result<(), almost_enough::StopReason> {
-    stop.check()
-}
-
-#[inline(never)]
-fn check_dyn_may_stop(stop: &dyn Stop) -> Result<(), almost_enough::StopReason> {
-    let stop = stop.may_stop().then_some(stop);
-    stop.check()
-}
-
-#[inline(never)]
-fn check_boxed_active(stop: &BoxedStop) -> Result<(), almost_enough::StopReason> {
-    let stop = stop.active_stop();
-    stop.check()
-}
-
-#[inline(never)]
-fn check_dynstop_active(stop: &DynStop) -> Result<(), almost_enough::StopReason> {
-    let stop = stop.active_stop();
-    stop.check()
-}
-
-// ── Hot loop macro ──────────────────────────────────────────────────
-// Inlined into each benchmark closure so the compiler sees the full
-// picture — exactly like real code. No #[inline(never)] boundary.
-
+/// Hot loop that checks `stop` every CHECK_INTERVAL iterations.
+/// `black_box` is on the accumulator result only — the stop reference
+/// is not obscured, so the compiler can optimize check() normally.
 macro_rules! hot_loop {
     ($stop:expr) => {{
-        let stop = $stop;
+        let stop = &$stop;
         let mut acc = 0usize;
         for i in 0..HOT_LOOP_ITERS {
             if i % CHECK_INTERVAL == 0 {
@@ -70,8 +34,6 @@ macro_rules! hot_loop {
     }};
 }
 
-/// Run check() 100 times to lift measurement above timer resolution.
-/// Per-call time = measured / 100.
 #[inline(never)]
 fn check_100(stop: &dyn Stop) {
     for _ in 0..100 {
@@ -81,17 +43,19 @@ fn check_100(stop: &dyn Stop) {
 
 fn main() {
     let result = zenbench::run(|suite| {
-        // ── Batched check (100x inner loop) ─────────────────────────
-        // Lifts sub-ns operations above timer resolution for validation.
-        // Reported times are for 100 calls. Divide by 100 for per-call cost.
+        // ═══════════════════════════════════════════════════════════
+        // Per-call cost: 100x inner loop for timer accuracy.
+        // Reported times are for 100 calls. Throughput shows per-call rate.
+        // ═══════════════════════════════════════════════════════════
 
-        suite.compare("check_100x", |group| {
+        suite.compare("per_call_cost", |group| {
             group.config().rounds(200).cache_firewall(false).sort_by_speed(true);
             group.throughput(zenbench::Throughput::Elements(100));
             group.throughput_unit("checks");
             group.baseline("impl Stop (Unstoppable)");
 
-            // -- Generic (compiler sees concrete type) --
+            // ── Generic (compiler sees concrete type) ───────────
+            group.subgroup("Generic");
 
             group.bench("impl Stop (Unstoppable)", |b| {
                 let stop = Unstoppable;
@@ -111,22 +75,11 @@ fn main() {
                 })
             });
 
-            // -- Single dyn dispatch --
+            // ── Optimized (may_stop / active_stop) ──────────────
+            group.subgroup("Optimized");
 
-            group.bench("&dyn Stop (Unstoppable)", |b| {
-                let stop = Unstoppable;
-                b.iter(|| check_100(&stop))
-            });
-
-            group.bench("&dyn Stop (Stopper)", |b| {
-                let stop = Stopper::new();
-                b.iter(|| check_100(&stop))
-            });
-
-            // -- &DynStop (concrete type known, one inner dispatch) --
-
-            group.bench("&DynStop (Unstoppable)", |b| {
-                let stop = Unstoppable.into_dyn();
+            group.bench("Option<None> (may_stop)", |b| {
+                let stop: Option<&dyn Stop> = None;
                 b.iter(|| {
                     for _ in 0..100 {
                         let _ = zenbench::black_box(&stop).check();
@@ -134,62 +87,15 @@ fn main() {
                 })
             });
 
-            group.bench("&DynStop (Stopper)", |b| {
-                let stop = Stopper::new().into_dyn();
+            group.bench("Option<Some(Stopper)>", |b| {
+                let stopper = Stopper::new();
+                let stop: Option<&dyn Stop> = Some(&stopper);
                 b.iter(|| {
                     for _ in 0..100 {
                         let _ = zenbench::black_box(&stop).check();
                     }
                 })
             });
-
-            // -- DynStop owned (includes Arc::clone per sample) --
-
-            group.bench("DynStop owned (Unstoppable)", |b| {
-                let stop = Unstoppable.into_dyn();
-                b.iter(|| {
-                    let stop = zenbench::black_box(&stop).clone();
-                    for _ in 0..100 {
-                        let _ = stop.check();
-                    }
-                })
-            });
-
-            group.bench("DynStop owned (Stopper)", |b| {
-                let stop = Stopper::new().into_dyn();
-                b.iter(|| {
-                    let stop = zenbench::black_box(&stop).clone();
-                    for _ in 0..100 {
-                        let _ = stop.check();
-                    }
-                })
-            });
-
-            // -- DynStop behind &dyn Stop (double dispatch) --
-
-            group.bench("&dyn Stop <- DynStop (Unstoppable)", |b| {
-                let stop = Unstoppable.into_dyn();
-                b.iter(|| check_100(&stop as &dyn Stop))
-            });
-
-            group.bench("&dyn Stop <- DynStop (Stopper)", |b| {
-                let stop = Stopper::new().into_dyn();
-                b.iter(|| check_100(&stop as &dyn Stop))
-            });
-
-            // -- BoxedStop behind &dyn Stop (double dispatch) --
-
-            group.bench("&dyn Stop <- BoxedStop (Unstoppable)", |b| {
-                let stop = Unstoppable.into_boxed();
-                b.iter(|| check_100(&stop as &dyn Stop))
-            });
-
-            group.bench("&dyn Stop <- BoxedStop (Stopper)", |b| {
-                let stop = Stopper::new().into_boxed();
-                b.iter(|| check_100(&stop as &dyn Stop))
-            });
-
-            // -- DynStop.active_stop() (collapses to inner) --
 
             group.bench("DynStop.active_stop (Unstoppable)", |b| {
                 let stop = Unstoppable.into_dyn();
@@ -211,302 +117,137 @@ fn main() {
                 })
             });
 
-            // -- Option patterns (the may_stop() payoff) --
+            // ── Single dispatch (&dyn Stop, &DynStop) ───────────
+            group.subgroup("Single dispatch");
 
-            group.bench("Option<&dyn Stop> = None", |b| {
-                let stop: Option<&dyn Stop> = None;
-                b.iter(|| {
-                    for _ in 0..100 {
-                        let _ = zenbench::black_box(&stop).check();
-                    }
-                })
-            });
-
-            group.bench("Option<&dyn Stop> = Some(Stopper)", |b| {
-                let stopper = Stopper::new();
-                let stop: Option<&dyn Stop> = Some(&stopper);
-                b.iter(|| {
-                    for _ in 0..100 {
-                        let _ = zenbench::black_box(&stop).check();
-                    }
-                })
-            });
-        });
-
-        // ── Single check: all Stop types ────────────────────────────
-
-        suite.compare("check_types", |group| {
-            group.config().rounds(200).cache_firewall(false).sort_by_speed(true);
-
-            group.bench("unstoppable", |b| {
+            group.bench("&dyn Stop (Unstoppable)", |b| {
                 let stop = Unstoppable;
-                b.iter(|| zenbench::black_box(&stop).check())
+                b.iter(|| check_100(&stop))
             });
 
-            group.bench("stop_source", |b| {
-                let stop = StopSource::new();
-                b.iter(|| zenbench::black_box(&stop).check())
-            });
-
-            group.bench("stop_ref", |b| {
-                let source = StopSource::new();
-                let stop = source.as_ref();
-                b.iter(|| zenbench::black_box(&stop).check())
-            });
-
-            group.bench("stopper", |b| {
+            group.bench("&dyn Stop (Stopper)", |b| {
                 let stop = Stopper::new();
-                b.iter(|| zenbench::black_box(&stop).check())
+                b.iter(|| check_100(&stop))
             });
 
-            group.bench("sync_stopper", |b| {
-                let stop = SyncStopper::new();
-                b.iter(|| zenbench::black_box(&stop).check())
-            });
-
-            group.bench("fn_stop", |b| {
-                let stop = FnStop::new(|| false);
-                b.iter(|| zenbench::black_box(&stop).check())
-            });
-
-            group.bench("boxed_unstoppable", |b| {
-                let stop = Unstoppable.into_boxed();
-                b.iter(|| zenbench::black_box(&stop).check())
-            });
-
-            group.bench("boxed_stopper", |b| {
-                let stop = Stopper::new().into_boxed();
-                b.iter(|| zenbench::black_box(&stop).check())
-            });
-
-            group.bench("dyn_unstoppable", |b| {
+            group.bench("&DynStop (Unstoppable)", |b| {
                 let stop = Unstoppable.into_dyn();
-                b.iter(|| zenbench::black_box(&stop).check())
+                b.iter(|| {
+                    for _ in 0..100 {
+                        let _ = zenbench::black_box(&stop).check();
+                    }
+                })
             });
 
-            group.bench("dyn_stopper", |b| {
+            group.bench("&DynStop (Stopper)", |b| {
                 let stop = Stopper::new().into_dyn();
-                b.iter(|| zenbench::black_box(&stop).check())
+                b.iter(|| {
+                    for _ in 0..100 {
+                        let _ = zenbench::black_box(&stop).check();
+                    }
+                })
             });
 
-            group.bench("with_timeout", |b| {
+            group.bench("DynStop owned (Stopper)", |b| {
+                let stop = Stopper::new().into_dyn();
+                b.iter(|| {
+                    let stop = zenbench::black_box(&stop).clone();
+                    for _ in 0..100 {
+                        let _ = stop.check();
+                    }
+                })
+            });
+
+            // ── Double dispatch (wrapped behind &dyn Stop) ──────
+            group.subgroup("Double dispatch");
+
+            group.bench("&dyn Stop <- BoxedStop (Stopper)", |b| {
+                let stop = Stopper::new().into_boxed();
+                b.iter(|| check_100(&stop as &dyn Stop))
+            });
+
+            group.bench("&dyn Stop <- DynStop (Stopper)", |b| {
+                let stop = Stopper::new().into_dyn();
+                b.iter(|| check_100(&stop as &dyn Stop))
+            });
+
+            // ── Exotic types ────────────────────────────────────
+            group.subgroup("Exotic");
+
+            group.bench("WithTimeout", |b| {
                 let source = StopSource::new();
                 let stop = source.as_ref().with_timeout(Duration::from_secs(3600));
-                b.iter(|| zenbench::black_box(&stop).check())
+                b.iter(|| {
+                    for _ in 0..100 {
+                        let _ = zenbench::black_box(&stop).check();
+                    }
+                })
             });
 
-            group.bench("child_root", |b| {
-                let stop = ChildStopper::new();
-                b.iter(|| zenbench::black_box(&stop).check())
-            });
-
-            group.bench("child_depth_1", |b| {
-                let parent = ChildStopper::new();
-                let stop = parent.child();
-                b.iter(|| zenbench::black_box(&stop).check())
-            });
-
-            group.bench("child_depth_3", |b| {
+            group.bench("ChildStopper depth 3", |b| {
                 let g0 = ChildStopper::new();
                 let g1 = g0.child();
                 let g2 = g1.child();
                 let stop = g2.child();
-                b.iter(|| zenbench::black_box(&stop).check())
+                b.iter(|| {
+                    for _ in 0..100 {
+                        let _ = zenbench::black_box(&stop).check();
+                    }
+                })
             });
 
-            group.bench("or_stop", |b| {
+            group.bench("OrStop<StopRef, StopRef>", |b| {
                 let a = StopSource::new();
                 let b_src = StopSource::new();
                 let stop: OrStop<_, _> = a.as_ref().or(b_src.as_ref());
-                b.iter(|| zenbench::black_box(&stop).check())
+                b.iter(|| {
+                    for _ in 0..100 {
+                        let _ = zenbench::black_box(&stop).check();
+                    }
+                })
             });
         });
 
-        // ── Dispatch: Stopper through every fn signature ────────────
-
-        suite.compare("dispatch_stopper", |group| {
-            group.config().rounds(200).cache_firewall(false).sort_by_speed(true);
-            group.baseline("generic");
-
-            group.bench("generic", |b| {
-                let stop = Stopper::new();
-                b.iter(|| check_generic(zenbench::black_box(&stop)))
-            });
-
-            group.bench("dyn", |b| {
-                let stop = Stopper::new();
-                b.iter(|| check_dyn(zenbench::black_box(&stop)))
-            });
-
-            group.bench("boxed", |b| {
-                let stop = Stopper::new().into_boxed();
-                b.iter(|| zenbench::black_box(&stop).check())
-            });
-
-            group.bench("dynstop", |b| {
-                let stop = Stopper::new().into_dyn();
-                b.iter(|| zenbench::black_box(&stop).check())
-            });
-
-            group.bench("dynstop_as_dyn", |b| {
-                let stop = Stopper::new().into_dyn();
-                b.iter(|| check_dyn(zenbench::black_box(&stop) as &dyn Stop))
-            });
-
-            group.bench("boxed_as_dyn", |b| {
-                let stop = Stopper::new().into_boxed();
-                b.iter(|| check_dyn(zenbench::black_box(&stop) as &dyn Stop))
-            });
-        });
-
-        // ── Dispatch: Unstoppable through every fn signature ────────
-
-        suite.compare("dispatch_unstoppable", |group| {
-            group.config().rounds(200).cache_firewall(false).sort_by_speed(true);
-            group.baseline("generic");
-
-            group.bench("generic", |b| {
-                let stop = Unstoppable;
-                b.iter(|| check_generic(zenbench::black_box(&stop)))
-            });
-
-            group.bench("dyn", |b| {
-                let stop = Unstoppable;
-                b.iter(|| check_dyn(zenbench::black_box(&stop)))
-            });
-
-            group.bench("dyn_may_stop", |b| {
-                let stop = Unstoppable;
-                b.iter(|| check_dyn_may_stop(zenbench::black_box(&stop)))
-            });
-
-            group.bench("boxed", |b| {
-                let stop = Unstoppable.into_boxed();
-                b.iter(|| zenbench::black_box(&stop).check())
-            });
-
-            group.bench("boxed_active", |b| {
-                let stop = Unstoppable.into_boxed();
-                b.iter(|| check_boxed_active(zenbench::black_box(&stop)))
-            });
-
-            group.bench("dynstop", |b| {
-                let stop = Unstoppable.into_dyn();
-                b.iter(|| zenbench::black_box(&stop).check())
-            });
-
-            group.bench("dynstop_active", |b| {
-                let stop = Unstoppable.into_dyn();
-                b.iter(|| check_dynstop_active(zenbench::black_box(&stop)))
-            });
-        });
-
-        // ── Optimization: raw vs may_stop vs active_stop ────────────
-
-        suite.compare("optimize_unstoppable", |group| {
-            group.config().rounds(200).cache_firewall(false).sort_by_speed(true);
-            group.baseline("dyn_raw");
-
-            group.bench("dyn_raw", |b| {
-                let stop = Unstoppable;
-                b.iter(|| check_dyn(zenbench::black_box(&stop)))
-            });
-
-            group.bench("dyn_may_stop", |b| {
-                let stop = Unstoppable;
-                b.iter(|| check_dyn_may_stop(zenbench::black_box(&stop)))
-            });
-
-            group.bench("boxed_raw", |b| {
-                let stop = Unstoppable.into_boxed();
-                b.iter(|| zenbench::black_box(&stop).check())
-            });
-
-            group.bench("boxed_active", |b| {
-                let stop = Unstoppable.into_boxed();
-                b.iter(|| check_boxed_active(zenbench::black_box(&stop)))
-            });
-
-            group.bench("dynstop_raw", |b| {
-                let stop = Unstoppable.into_dyn();
-                b.iter(|| zenbench::black_box(&stop).check())
-            });
-
-            group.bench("dynstop_active", |b| {
-                let stop = Unstoppable.into_dyn();
-                b.iter(|| check_dynstop_active(zenbench::black_box(&stop)))
-            });
-        });
-
-        suite.compare("optimize_stopper", |group| {
-            group.config().rounds(200).cache_firewall(false).sort_by_speed(true);
-            group.baseline("dyn_raw");
-
-            group.bench("dyn_raw", |b| {
-                let stop = Stopper::new();
-                b.iter(|| check_dyn(zenbench::black_box(&stop)))
-            });
-
-            group.bench("dyn_may_stop", |b| {
-                let stop = Stopper::new();
-                b.iter(|| check_dyn_may_stop(zenbench::black_box(&stop)))
-            });
-
-            group.bench("boxed_raw", |b| {
-                let stop = Stopper::new().into_boxed();
-                b.iter(|| zenbench::black_box(&stop).check())
-            });
-
-            group.bench("boxed_active", |b| {
-                let stop = Stopper::new().into_boxed();
-                b.iter(|| check_boxed_active(zenbench::black_box(&stop)))
-            });
-
-            group.bench("dynstop_raw", |b| {
-                let stop = Stopper::new().into_dyn();
-                b.iter(|| zenbench::black_box(&stop).check())
-            });
-
-            group.bench("dynstop_active", |b| {
-                let stop = Stopper::new().into_dyn();
-                b.iter(|| check_dynstop_active(zenbench::black_box(&stop)))
-            });
-        });
-
-        // ── Hot loops: 10k iterations, check every 64 ───────────────
+        // ═══════════════════════════════════════════════════════════
+        // Hot loops: 10k iterations, check() every 64.
+        // Measures real-world overhead with work between checks.
+        // ═══════════════════════════════════════════════════════════
 
         suite.compare("hot_loop_unstoppable", |group| {
             group.config().rounds(100).cache_firewall(false).sort_by_speed(true);
             group.baseline("generic");
 
+            group.subgroup("Zero-cost paths");
             group.bench("generic", |b| {
                 let stop = Unstoppable;
-                b.iter(|| hot_loop!(zenbench::black_box(&stop)))
+                b.iter(|| hot_loop!(stop))
             });
 
-            group.bench("&dyn Stop", |b| {
-                let stop = Unstoppable;
-                let stop: &dyn Stop = &stop;
-                b.iter(|| hot_loop!(zenbench::black_box(stop)))
-            });
-
+            group.subgroup("Optimized dyn");
             group.bench("&dyn Stop + may_stop", |b| {
                 let stop = Unstoppable;
                 let stop: &dyn Stop = &stop;
                 let stop = stop.may_stop().then_some(stop);
-                b.iter(|| hot_loop!(zenbench::black_box(&stop)))
-            });
-
-            group.bench("BoxedStop.active_stop", |b| {
-                let stop = Unstoppable.into_boxed();
-                let stop = stop.active_stop();
-                b.iter(|| hot_loop!(zenbench::black_box(&stop)))
+                b.iter(|| hot_loop!(stop))
             });
 
             group.bench("DynStop.active_stop", |b| {
                 let stop = Unstoppable.into_dyn();
                 let stop = stop.active_stop();
-                b.iter(|| hot_loop!(zenbench::black_box(&stop)))
+                b.iter(|| hot_loop!(stop))
+            });
+
+            group.bench("BoxedStop.active_stop", |b| {
+                let stop = Unstoppable.into_boxed();
+                let stop = stop.active_stop();
+                b.iter(|| hot_loop!(stop))
+            });
+
+            group.subgroup("Raw dyn (no optimization)");
+            group.bench("&dyn Stop", |b| {
+                let stop = Unstoppable;
+                let stop: &dyn Stop = &stop;
+                b.iter(|| hot_loop!(stop))
             });
         });
 
@@ -514,56 +255,57 @@ fn main() {
             group.config().rounds(100).cache_firewall(false).sort_by_speed(true);
             group.baseline("generic");
 
+            group.subgroup("Direct");
             group.bench("generic", |b| {
                 let stop = Stopper::new();
-                b.iter(|| hot_loop!(zenbench::black_box(&stop)))
+                b.iter(|| hot_loop!(stop))
             });
 
-            group.bench("&dyn Stop", |b| {
-                let stop = Stopper::new();
-                let stop: &dyn Stop = &stop;
-                b.iter(|| hot_loop!(zenbench::black_box(stop)))
-            });
-
+            group.subgroup("Optimized dyn");
             group.bench("&dyn Stop + may_stop", |b| {
                 let stop = Stopper::new();
                 let stop: &dyn Stop = &stop;
                 let stop = stop.may_stop().then_some(stop);
-                b.iter(|| hot_loop!(zenbench::black_box(&stop)))
-            });
-
-            group.bench("BoxedStop.active_stop", |b| {
-                let stop = Stopper::new().into_boxed();
-                let stop = stop.active_stop();
-                b.iter(|| hot_loop!(zenbench::black_box(&stop)))
+                b.iter(|| hot_loop!(stop))
             });
 
             group.bench("DynStop.active_stop", |b| {
                 let stop = Stopper::new().into_dyn();
                 let stop = stop.active_stop();
-                b.iter(|| hot_loop!(zenbench::black_box(&stop)))
+                b.iter(|| hot_loop!(stop))
+            });
+
+            group.bench("BoxedStop.active_stop", |b| {
+                let stop = Stopper::new().into_boxed();
+                let stop = stop.active_stop();
+                b.iter(|| hot_loop!(stop))
+            });
+
+            group.subgroup("Raw dyn (no optimization)");
+            group.bench("&dyn Stop", |b| {
+                let stop = Stopper::new();
+                let stop: &dyn Stop = &stop;
+                b.iter(|| hot_loop!(stop))
             });
         });
 
-        // ── Error path: cancelled ───────────────────────────────────
+        // ═══════════════════════════════════════════════════════════
+        // Error path + cold cache
+        // ═══════════════════════════════════════════════════════════
 
         suite.compare("check_cancelled", |group| {
             group.config().rounds(200).cache_firewall(false);
 
-            group.bench("stopper", |b| {
+            group.bench("Stopper", |b| {
                 let stop = Stopper::cancelled();
                 b.iter(|| zenbench::black_box(&stop).check())
             });
 
-            group.bench("sync_stopper", |b| {
+            group.bench("SyncStopper", |b| {
                 let stop = SyncStopper::cancelled();
                 b.iter(|| zenbench::black_box(&stop).check())
             });
         });
-
-        // ── Cold cache: same hot loops WITH cache firewall ──────────
-        // Shows the cost when stop token data is evicted from L1/L2,
-        // e.g., after context switches or large working sets.
 
         suite.compare("cold_cache_stopper", |group| {
             group.config().rounds(100).cache_firewall(true).sort_by_speed(true);
@@ -572,19 +314,19 @@ fn main() {
             group.bench("&dyn Stop", |b| {
                 let stop = Stopper::new();
                 let stop: &dyn Stop = &stop;
-                b.iter(|| hot_loop!(zenbench::black_box(stop)))
-            });
-
-            group.bench("BoxedStop.active_stop", |b| {
-                let stop = Stopper::new().into_boxed();
-                let stop = stop.active_stop();
-                b.iter(|| hot_loop!(zenbench::black_box(&stop)))
+                b.iter(|| hot_loop!(stop))
             });
 
             group.bench("DynStop.active_stop", |b| {
                 let stop = Stopper::new().into_dyn();
                 let stop = stop.active_stop();
-                b.iter(|| hot_loop!(zenbench::black_box(&stop)))
+                b.iter(|| hot_loop!(stop))
+            });
+
+            group.bench("BoxedStop.active_stop", |b| {
+                let stop = Stopper::new().into_boxed();
+                let stop = stop.active_stop();
+                b.iter(|| hot_loop!(stop))
             });
         });
     });

--- a/crates/almost-enough/benches/stop_check_zen.rs
+++ b/crates/almost-enough/benches/stop_check_zen.rs
@@ -130,10 +130,11 @@ fn main() {
     let result = zenbench::run(|suite| {
         // ── Batched check (100x inner loop) ─────────────────────────
         // Lifts sub-ns operations above timer resolution for validation.
-        // Divide reported times by 100 for per-call cost.
+        // Reported times are for 100 calls. Divide by 100 for per-call cost.
 
         suite.compare("check_100x", |group| {
             group.config().rounds(200).cache_firewall(false);
+            group.throughput(zenbench::Throughput::Elements(100));
 
             group.bench("unstoppable_generic", |b| {
                 let stop = Unstoppable;

--- a/crates/almost-enough/benches/stop_check_zen.rs
+++ b/crates/almost-enough/benches/stop_check_zen.rs
@@ -122,7 +122,7 @@ fn main() {
         // ── Single check: all Stop types ────────────────────────────
 
         suite.compare("check_types", |group| {
-            group.config().rounds(200);
+            group.config().rounds(200).cache_firewall(false);
 
             group.bench("unstoppable", |b| {
                 let stop = Unstoppable;
@@ -211,7 +211,7 @@ fn main() {
         // ── Dispatch: Stopper through every fn signature ────────────
 
         suite.compare("dispatch_stopper", |group| {
-            group.config().rounds(200);
+            group.config().rounds(200).cache_firewall(false);
 
             group.bench("generic", |b| {
                 let stop = Stopper::new();
@@ -247,7 +247,7 @@ fn main() {
         // ── Dispatch: Unstoppable through every fn signature ────────
 
         suite.compare("dispatch_unstoppable", |group| {
-            group.config().rounds(200);
+            group.config().rounds(200).cache_firewall(false);
 
             group.bench("generic", |b| {
                 let stop = Unstoppable;
@@ -288,7 +288,7 @@ fn main() {
         // ── Optimization: raw vs may_stop vs active_stop ────────────
 
         suite.compare("optimize_unstoppable", |group| {
-            group.config().rounds(200);
+            group.config().rounds(200).cache_firewall(false);
 
             group.bench("dyn_raw", |b| {
                 let stop = Unstoppable;
@@ -322,7 +322,7 @@ fn main() {
         });
 
         suite.compare("optimize_stopper", |group| {
-            group.config().rounds(200);
+            group.config().rounds(200).cache_firewall(false);
 
             group.bench("dyn_raw", |b| {
                 let stop = Stopper::new();
@@ -358,7 +358,7 @@ fn main() {
         // ── Hot loops: 10k iterations, check every 64 ───────────────
 
         suite.compare("hot_loop_unstoppable", |group| {
-            group.config().rounds(100);
+            group.config().rounds(100).cache_firewall(false);
 
             group.bench("generic", |b| b.iter(|| hot_loop_generic(&Unstoppable)));
 
@@ -384,7 +384,7 @@ fn main() {
         });
 
         suite.compare("hot_loop_stopper", |group| {
-            group.config().rounds(100);
+            group.config().rounds(100).cache_firewall(false);
 
             group.bench("generic", |b| {
                 let stop = Stopper::new();
@@ -415,7 +415,7 @@ fn main() {
         // ── Error path: cancelled ───────────────────────────────────
 
         suite.compare("check_cancelled", |group| {
-            group.config().rounds(200);
+            group.config().rounds(200).cache_firewall(false);
 
             group.bench("stopper", |b| {
                 let stop = Stopper::cancelled();
@@ -425,6 +425,29 @@ fn main() {
             group.bench("sync_stopper", |b| {
                 let stop = SyncStopper::cancelled();
                 b.iter(|| zenbench::black_box(&stop).check())
+            });
+        });
+
+        // ── Cold cache: same hot loops WITH cache firewall ──────────
+        // Shows the cost when stop token data is evicted from L1/L2,
+        // e.g., after context switches or large working sets.
+
+        suite.compare("cold_cache_stopper", |group| {
+            group.config().rounds(100).cache_firewall(true);
+
+            group.bench("dyn", |b| {
+                let stop = Stopper::new();
+                b.iter(|| hot_loop_dyn(&stop))
+            });
+
+            group.bench("boxed_active", |b| {
+                let stop = Stopper::new().into_boxed();
+                b.iter(|| hot_loop_boxed_active(&stop))
+            });
+
+            group.bench("dynstop_active", |b| {
+                let stop = Stopper::new().into_dyn();
+                b.iter(|| hot_loop_dynstop_active(&stop))
             });
         });
     });

--- a/crates/almost-enough/benches/stop_check_zen.rs
+++ b/crates/almost-enough/benches/stop_check_zen.rs
@@ -136,7 +136,9 @@ fn main() {
             group.config().rounds(200).cache_firewall(false);
             group.throughput(zenbench::Throughput::Elements(100));
 
-            group.bench("unstoppable_generic", |b| {
+            // -- Generic (compiler sees concrete type) --
+
+            group.bench("impl Stop (Unstoppable)", |b| {
                 let stop = Unstoppable;
                 b.iter(|| {
                     for _ in 0..100 {
@@ -145,7 +147,7 @@ fn main() {
                 })
             });
 
-            group.bench("stopper_generic", |b| {
+            group.bench("impl Stop (Stopper)", |b| {
                 let stop = Stopper::new();
                 b.iter(|| {
                     for _ in 0..100 {
@@ -154,75 +156,109 @@ fn main() {
                 })
             });
 
-            group.bench("unstoppable_dyn", |b| {
+            // -- Single dyn dispatch --
+
+            group.bench("&dyn Stop (Unstoppable)", |b| {
                 let stop = Unstoppable;
                 b.iter(|| check_100(&stop))
             });
 
-            group.bench("stopper_dyn", |b| {
+            group.bench("&dyn Stop (Stopper)", |b| {
                 let stop = Stopper::new();
                 b.iter(|| check_100(&stop))
             });
 
-            group.bench("boxed_unstoppable", |b| {
+            // -- &DynStop (concrete type known, one inner dispatch) --
+
+            group.bench("&DynStop (Unstoppable)", |b| {
+                let stop = Unstoppable.into_dyn();
+                b.iter(|| {
+                    for _ in 0..100 {
+                        let _ = zenbench::black_box(&stop).check();
+                    }
+                })
+            });
+
+            group.bench("&DynStop (Stopper)", |b| {
+                let stop = Stopper::new().into_dyn();
+                b.iter(|| {
+                    for _ in 0..100 {
+                        let _ = zenbench::black_box(&stop).check();
+                    }
+                })
+            });
+
+            // -- DynStop owned (includes Arc::clone per sample) --
+
+            group.bench("DynStop owned (Unstoppable)", |b| {
+                let stop = Unstoppable.into_dyn();
+                b.iter(|| {
+                    let stop = zenbench::black_box(&stop).clone();
+                    for _ in 0..100 {
+                        let _ = stop.check();
+                    }
+                })
+            });
+
+            group.bench("DynStop owned (Stopper)", |b| {
+                let stop = Stopper::new().into_dyn();
+                b.iter(|| {
+                    let stop = zenbench::black_box(&stop).clone();
+                    for _ in 0..100 {
+                        let _ = stop.check();
+                    }
+                })
+            });
+
+            // -- DynStop behind &dyn Stop (double dispatch) --
+
+            group.bench("&dyn Stop <- DynStop (Unstoppable)", |b| {
+                let stop = Unstoppable.into_dyn();
+                b.iter(|| check_100(&stop as &dyn Stop))
+            });
+
+            group.bench("&dyn Stop <- DynStop (Stopper)", |b| {
+                let stop = Stopper::new().into_dyn();
+                b.iter(|| check_100(&stop as &dyn Stop))
+            });
+
+            // -- BoxedStop behind &dyn Stop (double dispatch) --
+
+            group.bench("&dyn Stop <- BoxedStop (Unstoppable)", |b| {
                 let stop = Unstoppable.into_boxed();
                 b.iter(|| check_100(&stop as &dyn Stop))
             });
 
-            group.bench("boxed_stopper", |b| {
+            group.bench("&dyn Stop <- BoxedStop (Stopper)", |b| {
                 let stop = Stopper::new().into_boxed();
                 b.iter(|| check_100(&stop as &dyn Stop))
             });
 
-            group.bench("dyn_unstoppable", |b| {
-                let stop = Unstoppable.into_dyn();
-                b.iter(|| check_100(&stop as &dyn Stop))
-            });
+            // -- DynStop.active_stop() (collapses to inner) --
 
-            group.bench("dyn_stopper", |b| {
-                let stop = Stopper::new().into_dyn();
-                b.iter(|| check_100(&stop as &dyn Stop))
-            });
-
-            group.bench("dynstop_ref_unstoppable", |b| {
+            group.bench("DynStop.active_stop (Unstoppable)", |b| {
                 let stop = Unstoppable.into_dyn();
                 b.iter(|| {
+                    let active = stop.active_stop();
                     for _ in 0..100 {
-                        let _ = zenbench::black_box(&stop).check();
+                        let _ = zenbench::black_box(&active).check();
                     }
                 })
             });
 
-            group.bench("dynstop_ref_stopper", |b| {
+            group.bench("DynStop.active_stop (Stopper)", |b| {
                 let stop = Stopper::new().into_dyn();
                 b.iter(|| {
+                    let active = stop.active_stop();
                     for _ in 0..100 {
-                        let _ = zenbench::black_box(&stop).check();
+                        let _ = zenbench::black_box(&active).check();
                     }
                 })
             });
 
-            group.bench("dynstop_owned_unstoppable", |b| {
-                let stop = Unstoppable.into_dyn();
-                b.iter(|| {
-                    let stop = zenbench::black_box(&stop).clone();
-                    for _ in 0..100 {
-                        let _ = stop.check();
-                    }
-                })
-            });
+            // -- Option patterns (the may_stop() payoff) --
 
-            group.bench("dynstop_owned_stopper", |b| {
-                let stop = Stopper::new().into_dyn();
-                b.iter(|| {
-                    let stop = zenbench::black_box(&stop).clone();
-                    for _ in 0..100 {
-                        let _ = stop.check();
-                    }
-                })
-            });
-
-            group.bench("option_none", |b| {
+            group.bench("Option<&dyn Stop> = None", |b| {
                 let stop: Option<&dyn Stop> = None;
                 b.iter(|| {
                     for _ in 0..100 {
@@ -231,7 +267,7 @@ fn main() {
                 })
             });
 
-            group.bench("option_some_stopper", |b| {
+            group.bench("Option<&dyn Stop> = Some(Stopper)", |b| {
                 let stopper = Stopper::new();
                 let stop: Option<&dyn Stop> = Some(&stopper);
                 b.iter(|| {

--- a/crates/almost-enough/benches/stop_check_zen.rs
+++ b/crates/almost-enough/benches/stop_check_zen.rs
@@ -133,8 +133,10 @@ fn main() {
         // Reported times are for 100 calls. Divide by 100 for per-call cost.
 
         suite.compare("check_100x", |group| {
-            group.config().rounds(200).cache_firewall(false);
+            group.config().rounds(200).cache_firewall(false).sort_by_speed(true);
             group.throughput(zenbench::Throughput::Elements(100));
+            group.throughput_unit("checks");
+            group.baseline("impl Stop (Unstoppable)");
 
             // -- Generic (compiler sees concrete type) --
 
@@ -281,7 +283,7 @@ fn main() {
         // ── Single check: all Stop types ────────────────────────────
 
         suite.compare("check_types", |group| {
-            group.config().rounds(200).cache_firewall(false);
+            group.config().rounds(200).cache_firewall(false).sort_by_speed(true);
 
             group.bench("unstoppable", |b| {
                 let stop = Unstoppable;
@@ -370,7 +372,8 @@ fn main() {
         // ── Dispatch: Stopper through every fn signature ────────────
 
         suite.compare("dispatch_stopper", |group| {
-            group.config().rounds(200).cache_firewall(false);
+            group.config().rounds(200).cache_firewall(false).sort_by_speed(true);
+            group.baseline("generic");
 
             group.bench("generic", |b| {
                 let stop = Stopper::new();
@@ -406,7 +409,8 @@ fn main() {
         // ── Dispatch: Unstoppable through every fn signature ────────
 
         suite.compare("dispatch_unstoppable", |group| {
-            group.config().rounds(200).cache_firewall(false);
+            group.config().rounds(200).cache_firewall(false).sort_by_speed(true);
+            group.baseline("generic");
 
             group.bench("generic", |b| {
                 let stop = Unstoppable;
@@ -447,7 +451,8 @@ fn main() {
         // ── Optimization: raw vs may_stop vs active_stop ────────────
 
         suite.compare("optimize_unstoppable", |group| {
-            group.config().rounds(200).cache_firewall(false);
+            group.config().rounds(200).cache_firewall(false).sort_by_speed(true);
+            group.baseline("dyn_raw");
 
             group.bench("dyn_raw", |b| {
                 let stop = Unstoppable;
@@ -481,7 +486,8 @@ fn main() {
         });
 
         suite.compare("optimize_stopper", |group| {
-            group.config().rounds(200).cache_firewall(false);
+            group.config().rounds(200).cache_firewall(false).sort_by_speed(true);
+            group.baseline("dyn_raw");
 
             group.bench("dyn_raw", |b| {
                 let stop = Stopper::new();
@@ -517,7 +523,8 @@ fn main() {
         // ── Hot loops: 10k iterations, check every 64 ───────────────
 
         suite.compare("hot_loop_unstoppable", |group| {
-            group.config().rounds(100).cache_firewall(false);
+            group.config().rounds(100).cache_firewall(false).sort_by_speed(true);
+            group.baseline("generic");
 
             group.bench("generic", |b| b.iter(|| hot_loop_generic(&Unstoppable)));
 
@@ -543,7 +550,8 @@ fn main() {
         });
 
         suite.compare("hot_loop_stopper", |group| {
-            group.config().rounds(100).cache_firewall(false);
+            group.config().rounds(100).cache_firewall(false).sort_by_speed(true);
+            group.baseline("generic");
 
             group.bench("generic", |b| {
                 let stop = Stopper::new();
@@ -592,7 +600,8 @@ fn main() {
         // e.g., after context switches or large working sets.
 
         suite.compare("cold_cache_stopper", |group| {
-            group.config().rounds(100).cache_firewall(true);
+            group.config().rounds(100).cache_firewall(true).sort_by_speed(true);
+            group.baseline("dyn");
 
             group.bench("dyn", |b| {
                 let stop = Stopper::new();

--- a/crates/almost-enough/benches/stop_check_zen.rs
+++ b/crates/almost-enough/benches/stop_check_zen.rs
@@ -117,8 +117,74 @@ fn hot_loop_dynstop_active(stop: &DynStop) -> usize {
     acc
 }
 
+/// Run check() 100 times to lift measurement above timer resolution.
+/// Per-call time = measured / 100.
+#[inline(never)]
+fn check_100(stop: &dyn Stop) {
+    for _ in 0..100 {
+        let _ = zenbench::black_box(stop).check();
+    }
+}
+
 fn main() {
     let result = zenbench::run(|suite| {
+        // ── Batched check (100x inner loop) ─────────────────────────
+        // Lifts sub-ns operations above timer resolution for validation.
+        // Divide reported times by 100 for per-call cost.
+
+        suite.compare("check_100x", |group| {
+            group.config().rounds(200).cache_firewall(false);
+
+            group.bench("unstoppable", |b| {
+                let stop = Unstoppable;
+                b.iter(|| check_100(&stop))
+            });
+
+            group.bench("stopper", |b| {
+                let stop = Stopper::new();
+                b.iter(|| check_100(&stop))
+            });
+
+            group.bench("boxed_unstoppable", |b| {
+                let stop = Unstoppable.into_boxed();
+                b.iter(|| check_100(&stop as &dyn Stop))
+            });
+
+            group.bench("boxed_stopper", |b| {
+                let stop = Stopper::new().into_boxed();
+                b.iter(|| check_100(&stop as &dyn Stop))
+            });
+
+            group.bench("dyn_unstoppable", |b| {
+                let stop = Unstoppable.into_dyn();
+                b.iter(|| check_100(&stop as &dyn Stop))
+            });
+
+            group.bench("dyn_stopper", |b| {
+                let stop = Stopper::new().into_dyn();
+                b.iter(|| check_100(&stop as &dyn Stop))
+            });
+
+            group.bench("option_none", |b| {
+                let stop: Option<&dyn Stop> = None;
+                b.iter(|| {
+                    for _ in 0..100 {
+                        let _ = zenbench::black_box(&stop).check();
+                    }
+                })
+            });
+
+            group.bench("option_some_stopper", |b| {
+                let stopper = Stopper::new();
+                let stop: Option<&dyn Stop> = Some(&stopper);
+                b.iter(|| {
+                    for _ in 0..100 {
+                        let _ = zenbench::black_box(&stop).check();
+                    }
+                })
+            });
+        });
+
         // ── Single check: all Stop types ────────────────────────────
 
         suite.compare("check_types", |group| {

--- a/crates/almost-enough/benches/stop_check_zen.rs
+++ b/crates/almost-enough/benches/stop_check_zen.rs
@@ -135,12 +135,30 @@ fn main() {
         suite.compare("check_100x", |group| {
             group.config().rounds(200).cache_firewall(false);
 
-            group.bench("unstoppable", |b| {
+            group.bench("unstoppable_generic", |b| {
+                let stop = Unstoppable;
+                b.iter(|| {
+                    for _ in 0..100 {
+                        let _ = zenbench::black_box(&stop).check();
+                    }
+                })
+            });
+
+            group.bench("stopper_generic", |b| {
+                let stop = Stopper::new();
+                b.iter(|| {
+                    for _ in 0..100 {
+                        let _ = zenbench::black_box(&stop).check();
+                    }
+                })
+            });
+
+            group.bench("unstoppable_dyn", |b| {
                 let stop = Unstoppable;
                 b.iter(|| check_100(&stop))
             });
 
-            group.bench("stopper", |b| {
+            group.bench("stopper_dyn", |b| {
                 let stop = Stopper::new();
                 b.iter(|| check_100(&stop))
             });

--- a/crates/almost-enough/benches/stop_check_zen.rs
+++ b/crates/almost-enough/benches/stop_check_zen.rs
@@ -1,0 +1,435 @@
+//! Interleaved microbenchmarks for Stop dispatch patterns using zenbench.
+//!
+//! Unlike criterion (which runs each benchmark sequentially), zenbench
+//! interleaves samples from all benchmarks in a comparison group, ensuring
+//! each variant is measured under identical system conditions.
+//!
+//! Run with: cargo bench --bench stop_check_zen
+
+use std::time::Duration;
+
+use almost_enough::{
+    BoxedStop, ChildStopper, DynStop, FnStop, OrStop, Stop, StopExt, StopSource, Stopper,
+    SyncStopper, TimeoutExt, Unstoppable,
+};
+
+const HOT_LOOP_ITERS: usize = 10_000;
+const CHECK_INTERVAL: usize = 64;
+
+/// Trivial work unit to prevent loop elimination
+#[inline(always)]
+fn trivial_work(i: usize) -> usize {
+    zenbench::black_box(i.wrapping_mul(2654435761))
+}
+
+// ── Helpers: various fn signatures ──────────────────────────────────
+
+#[inline(never)]
+fn check_generic(stop: &impl Stop) -> Result<(), almost_enough::StopReason> {
+    stop.check()
+}
+
+#[inline(never)]
+fn check_dyn(stop: &dyn Stop) -> Result<(), almost_enough::StopReason> {
+    stop.check()
+}
+
+#[inline(never)]
+fn check_dyn_may_stop(stop: &dyn Stop) -> Result<(), almost_enough::StopReason> {
+    let stop = stop.may_stop().then_some(stop);
+    stop.check()
+}
+
+#[inline(never)]
+fn check_boxed_active(stop: &BoxedStop) -> Result<(), almost_enough::StopReason> {
+    let stop = stop.active_stop();
+    stop.check()
+}
+
+#[inline(never)]
+fn check_dynstop_active(stop: &DynStop) -> Result<(), almost_enough::StopReason> {
+    let stop = stop.active_stop();
+    stop.check()
+}
+
+// ── Helpers: hot loop variants ──────────────────────────────────────
+
+#[inline(never)]
+fn hot_loop_generic(stop: &impl Stop) -> usize {
+    let mut acc = 0usize;
+    for i in 0..HOT_LOOP_ITERS {
+        if i % CHECK_INTERVAL == 0 {
+            let _ = stop.check();
+        }
+        acc = acc.wrapping_add(trivial_work(i));
+    }
+    acc
+}
+
+#[inline(never)]
+fn hot_loop_dyn(stop: &dyn Stop) -> usize {
+    let mut acc = 0usize;
+    for i in 0..HOT_LOOP_ITERS {
+        if i % CHECK_INTERVAL == 0 {
+            let _ = stop.check();
+        }
+        acc = acc.wrapping_add(trivial_work(i));
+    }
+    acc
+}
+
+#[inline(never)]
+fn hot_loop_dyn_may_stop(stop: &dyn Stop) -> usize {
+    let stop = stop.may_stop().then_some(stop);
+    let mut acc = 0usize;
+    for i in 0..HOT_LOOP_ITERS {
+        if i % CHECK_INTERVAL == 0 {
+            let _ = stop.check();
+        }
+        acc = acc.wrapping_add(trivial_work(i));
+    }
+    acc
+}
+
+#[inline(never)]
+fn hot_loop_boxed_active(stop: &BoxedStop) -> usize {
+    let stop = stop.active_stop();
+    let mut acc = 0usize;
+    for i in 0..HOT_LOOP_ITERS {
+        if i % CHECK_INTERVAL == 0 {
+            let _ = stop.check();
+        }
+        acc = acc.wrapping_add(trivial_work(i));
+    }
+    acc
+}
+
+#[inline(never)]
+fn hot_loop_dynstop_active(stop: &DynStop) -> usize {
+    let stop = stop.active_stop();
+    let mut acc = 0usize;
+    for i in 0..HOT_LOOP_ITERS {
+        if i % CHECK_INTERVAL == 0 {
+            let _ = stop.check();
+        }
+        acc = acc.wrapping_add(trivial_work(i));
+    }
+    acc
+}
+
+fn main() {
+    let result = zenbench::run(|suite| {
+        // ── Single check: all Stop types ────────────────────────────
+
+        suite.compare("check_types", |group| {
+            group.config().rounds(200);
+
+            group.bench("unstoppable", |b| {
+                let stop = Unstoppable;
+                b.iter(|| zenbench::black_box(&stop).check())
+            });
+
+            group.bench("stop_source", |b| {
+                let stop = StopSource::new();
+                b.iter(|| zenbench::black_box(&stop).check())
+            });
+
+            group.bench("stop_ref", |b| {
+                let source = StopSource::new();
+                let stop = source.as_ref();
+                b.iter(|| zenbench::black_box(&stop).check())
+            });
+
+            group.bench("stopper", |b| {
+                let stop = Stopper::new();
+                b.iter(|| zenbench::black_box(&stop).check())
+            });
+
+            group.bench("sync_stopper", |b| {
+                let stop = SyncStopper::new();
+                b.iter(|| zenbench::black_box(&stop).check())
+            });
+
+            group.bench("fn_stop", |b| {
+                let stop = FnStop::new(|| false);
+                b.iter(|| zenbench::black_box(&stop).check())
+            });
+
+            group.bench("boxed_unstoppable", |b| {
+                let stop = Unstoppable.into_boxed();
+                b.iter(|| zenbench::black_box(&stop).check())
+            });
+
+            group.bench("boxed_stopper", |b| {
+                let stop = Stopper::new().into_boxed();
+                b.iter(|| zenbench::black_box(&stop).check())
+            });
+
+            group.bench("dyn_unstoppable", |b| {
+                let stop = Unstoppable.into_dyn();
+                b.iter(|| zenbench::black_box(&stop).check())
+            });
+
+            group.bench("dyn_stopper", |b| {
+                let stop = Stopper::new().into_dyn();
+                b.iter(|| zenbench::black_box(&stop).check())
+            });
+
+            group.bench("with_timeout", |b| {
+                let source = StopSource::new();
+                let stop = source.as_ref().with_timeout(Duration::from_secs(3600));
+                b.iter(|| zenbench::black_box(&stop).check())
+            });
+
+            group.bench("child_root", |b| {
+                let stop = ChildStopper::new();
+                b.iter(|| zenbench::black_box(&stop).check())
+            });
+
+            group.bench("child_depth_1", |b| {
+                let parent = ChildStopper::new();
+                let stop = parent.child();
+                b.iter(|| zenbench::black_box(&stop).check())
+            });
+
+            group.bench("child_depth_3", |b| {
+                let g0 = ChildStopper::new();
+                let g1 = g0.child();
+                let g2 = g1.child();
+                let stop = g2.child();
+                b.iter(|| zenbench::black_box(&stop).check())
+            });
+
+            group.bench("or_stop", |b| {
+                let a = StopSource::new();
+                let b_src = StopSource::new();
+                let stop: OrStop<_, _> = a.as_ref().or(b_src.as_ref());
+                b.iter(|| zenbench::black_box(&stop).check())
+            });
+        });
+
+        // ── Dispatch: Stopper through every fn signature ────────────
+
+        suite.compare("dispatch_stopper", |group| {
+            group.config().rounds(200);
+
+            group.bench("generic", |b| {
+                let stop = Stopper::new();
+                b.iter(|| check_generic(zenbench::black_box(&stop)))
+            });
+
+            group.bench("dyn", |b| {
+                let stop = Stopper::new();
+                b.iter(|| check_dyn(zenbench::black_box(&stop)))
+            });
+
+            group.bench("boxed", |b| {
+                let stop = Stopper::new().into_boxed();
+                b.iter(|| zenbench::black_box(&stop).check())
+            });
+
+            group.bench("dynstop", |b| {
+                let stop = Stopper::new().into_dyn();
+                b.iter(|| zenbench::black_box(&stop).check())
+            });
+
+            group.bench("dynstop_as_dyn", |b| {
+                let stop = Stopper::new().into_dyn();
+                b.iter(|| check_dyn(zenbench::black_box(&stop) as &dyn Stop))
+            });
+
+            group.bench("boxed_as_dyn", |b| {
+                let stop = Stopper::new().into_boxed();
+                b.iter(|| check_dyn(zenbench::black_box(&stop) as &dyn Stop))
+            });
+        });
+
+        // ── Dispatch: Unstoppable through every fn signature ────────
+
+        suite.compare("dispatch_unstoppable", |group| {
+            group.config().rounds(200);
+
+            group.bench("generic", |b| {
+                let stop = Unstoppable;
+                b.iter(|| check_generic(zenbench::black_box(&stop)))
+            });
+
+            group.bench("dyn", |b| {
+                let stop = Unstoppable;
+                b.iter(|| check_dyn(zenbench::black_box(&stop)))
+            });
+
+            group.bench("dyn_may_stop", |b| {
+                let stop = Unstoppable;
+                b.iter(|| check_dyn_may_stop(zenbench::black_box(&stop)))
+            });
+
+            group.bench("boxed", |b| {
+                let stop = Unstoppable.into_boxed();
+                b.iter(|| zenbench::black_box(&stop).check())
+            });
+
+            group.bench("boxed_active", |b| {
+                let stop = Unstoppable.into_boxed();
+                b.iter(|| check_boxed_active(zenbench::black_box(&stop)))
+            });
+
+            group.bench("dynstop", |b| {
+                let stop = Unstoppable.into_dyn();
+                b.iter(|| zenbench::black_box(&stop).check())
+            });
+
+            group.bench("dynstop_active", |b| {
+                let stop = Unstoppable.into_dyn();
+                b.iter(|| check_dynstop_active(zenbench::black_box(&stop)))
+            });
+        });
+
+        // ── Optimization: raw vs may_stop vs active_stop ────────────
+
+        suite.compare("optimize_unstoppable", |group| {
+            group.config().rounds(200);
+
+            group.bench("dyn_raw", |b| {
+                let stop = Unstoppable;
+                b.iter(|| check_dyn(zenbench::black_box(&stop)))
+            });
+
+            group.bench("dyn_may_stop", |b| {
+                let stop = Unstoppable;
+                b.iter(|| check_dyn_may_stop(zenbench::black_box(&stop)))
+            });
+
+            group.bench("boxed_raw", |b| {
+                let stop = Unstoppable.into_boxed();
+                b.iter(|| zenbench::black_box(&stop).check())
+            });
+
+            group.bench("boxed_active", |b| {
+                let stop = Unstoppable.into_boxed();
+                b.iter(|| check_boxed_active(zenbench::black_box(&stop)))
+            });
+
+            group.bench("dynstop_raw", |b| {
+                let stop = Unstoppable.into_dyn();
+                b.iter(|| zenbench::black_box(&stop).check())
+            });
+
+            group.bench("dynstop_active", |b| {
+                let stop = Unstoppable.into_dyn();
+                b.iter(|| check_dynstop_active(zenbench::black_box(&stop)))
+            });
+        });
+
+        suite.compare("optimize_stopper", |group| {
+            group.config().rounds(200);
+
+            group.bench("dyn_raw", |b| {
+                let stop = Stopper::new();
+                b.iter(|| check_dyn(zenbench::black_box(&stop)))
+            });
+
+            group.bench("dyn_may_stop", |b| {
+                let stop = Stopper::new();
+                b.iter(|| check_dyn_may_stop(zenbench::black_box(&stop)))
+            });
+
+            group.bench("boxed_raw", |b| {
+                let stop = Stopper::new().into_boxed();
+                b.iter(|| zenbench::black_box(&stop).check())
+            });
+
+            group.bench("boxed_active", |b| {
+                let stop = Stopper::new().into_boxed();
+                b.iter(|| check_boxed_active(zenbench::black_box(&stop)))
+            });
+
+            group.bench("dynstop_raw", |b| {
+                let stop = Stopper::new().into_dyn();
+                b.iter(|| zenbench::black_box(&stop).check())
+            });
+
+            group.bench("dynstop_active", |b| {
+                let stop = Stopper::new().into_dyn();
+                b.iter(|| check_dynstop_active(zenbench::black_box(&stop)))
+            });
+        });
+
+        // ── Hot loops: 10k iterations, check every 64 ───────────────
+
+        suite.compare("hot_loop_unstoppable", |group| {
+            group.config().rounds(100);
+
+            group.bench("generic", |b| b.iter(|| hot_loop_generic(&Unstoppable)));
+
+            group.bench("dyn", |b| {
+                let stop = Unstoppable;
+                b.iter(|| hot_loop_dyn(&stop))
+            });
+
+            group.bench("dyn_may_stop", |b| {
+                let stop = Unstoppable;
+                b.iter(|| hot_loop_dyn_may_stop(&stop))
+            });
+
+            group.bench("boxed_active", |b| {
+                let stop = Unstoppable.into_boxed();
+                b.iter(|| hot_loop_boxed_active(&stop))
+            });
+
+            group.bench("dynstop_active", |b| {
+                let stop = Unstoppable.into_dyn();
+                b.iter(|| hot_loop_dynstop_active(&stop))
+            });
+        });
+
+        suite.compare("hot_loop_stopper", |group| {
+            group.config().rounds(100);
+
+            group.bench("generic", |b| {
+                let stop = Stopper::new();
+                b.iter(|| hot_loop_generic(&stop))
+            });
+
+            group.bench("dyn", |b| {
+                let stop = Stopper::new();
+                b.iter(|| hot_loop_dyn(&stop))
+            });
+
+            group.bench("dyn_may_stop", |b| {
+                let stop = Stopper::new();
+                b.iter(|| hot_loop_dyn_may_stop(&stop))
+            });
+
+            group.bench("boxed_active", |b| {
+                let stop = Stopper::new().into_boxed();
+                b.iter(|| hot_loop_boxed_active(&stop))
+            });
+
+            group.bench("dynstop_active", |b| {
+                let stop = Stopper::new().into_dyn();
+                b.iter(|| hot_loop_dynstop_active(&stop))
+            });
+        });
+
+        // ── Error path: cancelled ───────────────────────────────────
+
+        suite.compare("check_cancelled", |group| {
+            group.config().rounds(200);
+
+            group.bench("stopper", |b| {
+                let stop = Stopper::cancelled();
+                b.iter(|| zenbench::black_box(&stop).check())
+            });
+
+            group.bench("sync_stopper", |b| {
+                let stop = SyncStopper::cancelled();
+                b.iter(|| zenbench::black_box(&stop).check())
+            });
+        });
+    });
+
+    if let Err(e) = result.save("stop_check_zen_results.json") {
+        eprintln!("Failed to save results: {e}");
+    }
+}

--- a/crates/almost-enough/benches/stop_check_zen.rs
+++ b/crates/almost-enough/benches/stop_check_zen.rs
@@ -184,6 +184,44 @@ fn main() {
                 b.iter(|| check_100(&stop as &dyn Stop))
             });
 
+            group.bench("dynstop_ref_unstoppable", |b| {
+                let stop = Unstoppable.into_dyn();
+                b.iter(|| {
+                    for _ in 0..100 {
+                        let _ = zenbench::black_box(&stop).check();
+                    }
+                })
+            });
+
+            group.bench("dynstop_ref_stopper", |b| {
+                let stop = Stopper::new().into_dyn();
+                b.iter(|| {
+                    for _ in 0..100 {
+                        let _ = zenbench::black_box(&stop).check();
+                    }
+                })
+            });
+
+            group.bench("dynstop_owned_unstoppable", |b| {
+                let stop = Unstoppable.into_dyn();
+                b.iter(|| {
+                    let stop = zenbench::black_box(&stop).clone();
+                    for _ in 0..100 {
+                        let _ = stop.check();
+                    }
+                })
+            });
+
+            group.bench("dynstop_owned_stopper", |b| {
+                let stop = Stopper::new().into_dyn();
+                b.iter(|| {
+                    let stop = zenbench::black_box(&stop).clone();
+                    for _ in 0..100 {
+                        let _ = stop.check();
+                    }
+                })
+            });
+
             group.bench("option_none", |b| {
                 let stop: Option<&dyn Stop> = None;
                 b.iter(|| {

--- a/crates/almost-enough/src/dyn_stop.rs
+++ b/crates/almost-enough/src/dyn_stop.rs
@@ -45,27 +45,19 @@ use crate::{Stop, StopReason};
 /// # Example
 ///
 /// ```rust
-/// use almost_enough::{DynStop, Stopper, Unstoppable, Stop, StopReason};
+/// use almost_enough::{DynStop, Stopper, Stop, StopReason};
 ///
-/// // Clone and send to another thread
 /// let stopper = Stopper::new();
 /// let stop = DynStop::new(stopper.clone());
-///
-/// let handle = std::thread::spawn({
-///     let stop = stop.clone(); // cheap Arc clone
-///     move || -> Result<(), StopReason> {
-///         for i in 0..1000 {
-///             stop.check()?;
-///         }
-///         Ok(())
-///     }
-/// });
+/// let stop2 = stop.clone(); // cheap Arc clone
 ///
 /// stopper.cancel();
-/// let result = handle.join().unwrap();
-/// assert!(result.is_err());
+/// assert!(stop.should_stop());
+/// assert!(stop2.should_stop()); // both see cancellation
 /// ```
-pub struct DynStop(Arc<dyn Stop + Send + Sync>);
+pub struct DynStop {
+    inner: Arc<dyn Stop + Send + Sync>,
+}
 
 impl DynStop {
     /// Create a new `DynStop` from any [`Stop`] implementation.
@@ -82,7 +74,9 @@ impl DynStop {
             drop(stop);
             return result;
         }
-        Self(Arc::new(stop))
+        Self {
+            inner: Arc::new(stop),
+        }
     }
 
     /// Create a `DynStop` from an existing `Arc<T>` without re-wrapping.
@@ -90,17 +84,33 @@ impl DynStop {
     /// This is zero-cost — just widens the pointer. Use this when you
     /// already have an `Arc`-wrapped stop type.
     ///
+    /// If `T` is `DynStop`, the inner Arc is extracted to avoid double
+    /// indirection (`Arc<Arc<dyn Stop>>`).
+    ///
     /// ```rust
     /// use almost_enough::{DynStop, Stopper, Stop};
+    /// # #[cfg(feature = "std")]
+    /// # fn main() {
     /// use std::sync::Arc;
     ///
     /// let stopper = Arc::new(Stopper::new());
     /// let stop = DynStop::from_arc(stopper); // pointer widening, no allocation
     /// assert!(!stop.should_stop());
+    /// # }
+    /// # #[cfg(not(feature = "std"))]
+    /// # fn main() {}
     /// ```
     #[inline]
     pub fn from_arc<T: Stop + 'static>(arc: Arc<T>) -> Self {
-        Self(arc as Arc<dyn Stop + Send + Sync>)
+        // Collapse Arc<DynStop> → reuse inner Arc
+        if TypeId::of::<T>() == TypeId::of::<DynStop>() {
+            let any_ref: &dyn Any = &*arc;
+            let inner = any_ref.downcast_ref::<DynStop>().unwrap();
+            return inner.clone();
+        }
+        Self {
+            inner: arc as Arc<dyn Stop + Send + Sync>,
+        }
     }
 
     /// Returns the effective inner stop if it may stop, collapsing indirection.
@@ -127,7 +137,7 @@ impl DynStop {
     /// ```
     #[inline]
     pub fn active_stop(&self) -> Option<&dyn Stop> {
-        let inner: &dyn Stop = &*self.0;
+        let inner: &dyn Stop = &*self.inner;
         if inner.may_stop() { Some(inner) } else { None }
     }
 }
@@ -135,24 +145,26 @@ impl DynStop {
 impl Clone for DynStop {
     #[inline]
     fn clone(&self) -> Self {
-        Self(Arc::clone(&self.0))
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
     }
 }
 
 impl Stop for DynStop {
     #[inline]
     fn check(&self) -> Result<(), StopReason> {
-        self.0.check()
+        self.inner.check()
     }
 
     #[inline]
     fn should_stop(&self) -> bool {
-        self.0.should_stop()
+        self.inner.should_stop()
     }
 
     #[inline]
     fn may_stop(&self) -> bool {
-        self.0.may_stop()
+        self.inner.may_stop()
     }
 }
 
@@ -200,6 +212,7 @@ mod tests {
         assert!(stop2.should_stop());
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn clone_send_to_thread() {
         let stopper = Stopper::new();

--- a/crates/almost-enough/src/dyn_stop.rs
+++ b/crates/almost-enough/src/dyn_stop.rs
@@ -1,0 +1,326 @@
+//! Arc-based cloneable dynamic dispatch for Stop.
+//!
+//! This module provides [`DynStop`], a shared-ownership wrapper that enables
+//! dynamic dispatch without monomorphization bloat, with cheap `Clone`.
+//!
+//! # DynStop vs BoxedStop
+//!
+//! | | `DynStop` | `BoxedStop` |
+//! |---|-----------|-------------|
+//! | Clone | Yes (Arc increment) | No |
+//! | Storage | `Arc<dyn Stop>` | `Box<dyn Stop>` |
+//! | Send to threads | Clone and move | Must wrap in Arc yourself |
+//! | Use case | Default choice | When Clone is unwanted |
+//!
+//! # Example
+//!
+//! ```rust
+//! use almost_enough::{DynStop, Stopper, Unstoppable, Stop};
+//!
+//! let stopper = Stopper::new();
+//! let stop = DynStop::new(stopper.clone());
+//! let stop2 = stop.clone(); // Arc increment, no allocation
+//!
+//! stopper.cancel();
+//! assert!(stop.should_stop());
+//! assert!(stop2.should_stop());
+//! ```
+
+use alloc::sync::Arc;
+use core::any::{Any, TypeId};
+
+use crate::{Stop, StopReason};
+
+/// A shared-ownership [`Stop`] implementation with cheap `Clone`.
+///
+/// Wraps any `Stop` in an `Arc` for shared ownership across threads.
+/// Cloning is an atomic increment — no heap allocation.
+///
+/// # Indirection Collapsing
+///
+/// `DynStop::new()` detects when you pass another `DynStop` and unwraps
+/// it instead of double-wrapping. `active_stop()` collapses to the inner
+/// concrete type for hot loops.
+///
+/// # Example
+///
+/// ```rust
+/// use almost_enough::{DynStop, Stopper, Unstoppable, Stop, StopReason};
+///
+/// // Clone and send to another thread
+/// let stopper = Stopper::new();
+/// let stop = DynStop::new(stopper.clone());
+///
+/// let handle = std::thread::spawn({
+///     let stop = stop.clone(); // cheap Arc clone
+///     move || -> Result<(), StopReason> {
+///         for i in 0..1000 {
+///             stop.check()?;
+///         }
+///         Ok(())
+///     }
+/// });
+///
+/// stopper.cancel();
+/// let result = handle.join().unwrap();
+/// assert!(result.is_err());
+/// ```
+pub struct DynStop(Arc<dyn Stop + Send + Sync>);
+
+impl DynStop {
+    /// Create a new `DynStop` from any [`Stop`] implementation.
+    ///
+    /// If `stop` is already a `DynStop`, it is unwrapped instead of
+    /// double-wrapping (no extra indirection).
+    #[inline]
+    pub fn new<T: Stop + 'static>(stop: T) -> Self {
+        // Collapse DynStop nesting: if T is DynStop, clone its inner Arc
+        if TypeId::of::<T>() == TypeId::of::<DynStop>() {
+            let any_ref: &dyn Any = &stop;
+            let inner = any_ref.downcast_ref::<DynStop>().unwrap();
+            let result = inner.clone();
+            drop(stop);
+            return result;
+        }
+        Self(Arc::new(stop))
+    }
+
+    /// Create a `DynStop` from an existing `Arc<T>` without re-wrapping.
+    ///
+    /// This is zero-cost — just widens the pointer. Use this when you
+    /// already have an `Arc`-wrapped stop type.
+    ///
+    /// ```rust
+    /// use almost_enough::{DynStop, Stopper, Stop};
+    /// use std::sync::Arc;
+    ///
+    /// let stopper = Arc::new(Stopper::new());
+    /// let stop = DynStop::from_arc(stopper); // pointer widening, no allocation
+    /// assert!(!stop.should_stop());
+    /// ```
+    #[inline]
+    pub fn from_arc<T: Stop + 'static>(arc: Arc<T>) -> Self {
+        Self(arc as Arc<dyn Stop + Send + Sync>)
+    }
+
+    /// Returns the effective inner stop if it may stop, collapsing indirection.
+    ///
+    /// The returned `&dyn Stop` points directly to the concrete type inside
+    /// the `Arc`, bypassing the `DynStop` wrapper. In a hot loop, subsequent
+    /// `check()` calls go through one vtable dispatch instead of two.
+    ///
+    /// Returns `None` if the inner stop is a no-op (e.g., `Unstoppable`).
+    ///
+    /// ```rust
+    /// use almost_enough::{DynStop, Stopper, Unstoppable, Stop, StopReason};
+    ///
+    /// fn hot_loop(stop: &DynStop) -> Result<(), StopReason> {
+    ///     let stop = stop.active_stop(); // Option<&dyn Stop>, collapsed
+    ///     for i in 0..1000 {
+    ///         stop.check()?;
+    ///     }
+    ///     Ok(())
+    /// }
+    ///
+    /// assert!(hot_loop(&DynStop::new(Unstoppable)).is_ok());
+    /// assert!(hot_loop(&DynStop::new(Stopper::new())).is_ok());
+    /// ```
+    #[inline]
+    pub fn active_stop(&self) -> Option<&dyn Stop> {
+        let inner: &dyn Stop = &*self.0;
+        if inner.may_stop() { Some(inner) } else { None }
+    }
+}
+
+impl Clone for DynStop {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self(Arc::clone(&self.0))
+    }
+}
+
+impl Stop for DynStop {
+    #[inline]
+    fn check(&self) -> Result<(), StopReason> {
+        self.0.check()
+    }
+
+    #[inline]
+    fn should_stop(&self) -> bool {
+        self.0.should_stop()
+    }
+
+    #[inline]
+    fn may_stop(&self) -> bool {
+        self.0.may_stop()
+    }
+}
+
+impl core::fmt::Debug for DynStop {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("DynStop").finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{FnStop, StopSource, Stopper, Unstoppable};
+
+    #[test]
+    fn from_unstoppable() {
+        let stop = DynStop::new(Unstoppable);
+        assert!(!stop.should_stop());
+        assert!(stop.check().is_ok());
+    }
+
+    #[test]
+    fn from_stopper() {
+        let stopper = Stopper::new();
+        let stop = DynStop::new(stopper.clone());
+
+        assert!(!stop.should_stop());
+
+        stopper.cancel();
+
+        assert!(stop.should_stop());
+        assert_eq!(stop.check(), Err(StopReason::Cancelled));
+    }
+
+    #[test]
+    fn clone_is_cheap() {
+        let stopper = Stopper::new();
+        let stop = DynStop::new(stopper.clone());
+        let stop2 = stop.clone();
+
+        stopper.cancel();
+
+        // Both clones see the cancellation (shared state)
+        assert!(stop.should_stop());
+        assert!(stop2.should_stop());
+    }
+
+    #[test]
+    fn clone_send_to_thread() {
+        let stopper = Stopper::new();
+        let stop = DynStop::new(stopper.clone());
+
+        let handle = std::thread::spawn({
+            let stop = stop.clone();
+            move || stop.should_stop()
+        });
+
+        stopper.cancel();
+        // Thread may or may not see cancellation depending on timing
+        let _ = handle.join().unwrap();
+    }
+
+    #[test]
+    fn is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<DynStop>();
+    }
+
+    #[test]
+    fn debug_format() {
+        let stop = DynStop::new(Unstoppable);
+        let debug = alloc::format!("{:?}", stop);
+        assert!(debug.contains("DynStop"));
+    }
+
+    #[test]
+    fn may_stop_delegates() {
+        assert!(!DynStop::new(Unstoppable).may_stop());
+        assert!(DynStop::new(Stopper::new()).may_stop());
+    }
+
+    #[test]
+    fn active_stop_unstoppable() {
+        let stop = DynStop::new(Unstoppable);
+        assert!(stop.active_stop().is_none());
+    }
+
+    #[test]
+    fn active_stop_stopper() {
+        let stopper = Stopper::new();
+        let stop = DynStop::new(stopper.clone());
+
+        let active = stop.active_stop();
+        assert!(active.is_some());
+        assert!(active.unwrap().check().is_ok());
+
+        stopper.cancel();
+        assert!(active.unwrap().should_stop());
+    }
+
+    #[test]
+    fn collapses_nested_dyn_stop() {
+        let inner = DynStop::new(Unstoppable);
+        let outer = DynStop::new(inner);
+        // Collapsed: outer wraps Arc<Unstoppable>, not Arc<DynStop<Arc<Unstoppable>>>
+        assert!(!outer.may_stop());
+        assert!(outer.active_stop().is_none());
+    }
+
+    #[test]
+    fn collapses_nested_stopper() {
+        let stopper = Stopper::new();
+        let inner = DynStop::new(stopper.clone());
+        let outer = DynStop::new(inner.clone());
+
+        // Both share the same Arc chain
+        stopper.cancel();
+        assert!(outer.should_stop());
+        assert!(inner.should_stop());
+    }
+
+    #[test]
+    fn from_arc() {
+        let stopper = Arc::new(Stopper::new());
+        let cancel_handle = stopper.clone();
+        let stop = DynStop::from_arc(stopper);
+
+        assert!(!stop.should_stop());
+        cancel_handle.cancel();
+        assert!(stop.should_stop());
+    }
+
+    #[test]
+    fn from_non_clone_fn_stop() {
+        // FnStop with non-Clone closure — DynStop doesn't need Clone on T
+        let flag = Arc::new(core::sync::atomic::AtomicBool::new(false));
+        let flag2 = flag.clone();
+        let stop = DynStop::new(FnStop::new(move || {
+            flag2.load(core::sync::atomic::Ordering::Relaxed)
+        }));
+
+        assert!(!stop.should_stop());
+
+        // Clone the DynStop (shares the Arc, not the closure)
+        let stop2 = stop.clone();
+        flag.store(true, core::sync::atomic::Ordering::Relaxed);
+
+        assert!(stop.should_stop());
+        assert!(stop2.should_stop());
+    }
+
+    #[test]
+    fn avoids_monomorphization() {
+        fn process(stop: DynStop) -> bool {
+            stop.should_stop()
+        }
+
+        assert!(!process(DynStop::new(Unstoppable)));
+        assert!(!process(DynStop::new(StopSource::new())));
+        assert!(!process(DynStop::new(Stopper::new())));
+    }
+
+    #[test]
+    fn hot_loop_pattern() {
+        let stop = DynStop::new(Unstoppable);
+        let active = stop.active_stop();
+        for _ in 0..1000 {
+            assert!(active.check().is_ok());
+        }
+    }
+}

--- a/crates/almost-enough/src/lib.rs
+++ b/crates/almost-enough/src/lib.rs
@@ -218,6 +218,10 @@ mod tree;
 #[cfg(feature = "alloc")]
 pub use boxed::BoxedStop;
 #[cfg(feature = "alloc")]
+mod dyn_stop;
+#[cfg(feature = "alloc")]
+pub use dyn_stop::DynStop;
+#[cfg(feature = "alloc")]
 pub use stopper::Stopper;
 #[cfg(feature = "alloc")]
 pub use sync_stopper::SyncStopper;
@@ -337,6 +341,36 @@ pub trait StopExt: Stop + Sized {
         Self: 'static,
     {
         BoxedStop::new(self)
+    }
+
+    /// Convert this stop into a shared, cloneable [`DynStop`].
+    ///
+    /// The result is `Clone` (via `Arc` increment) and can be sent across
+    /// threads. Use this when you need owned, cloneable type erasure.
+    ///
+    /// If `self` is already a `DynStop`, this is a no-op (no double-wrapping).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[cfg(feature = "alloc")]
+    /// # fn main() {
+    /// use almost_enough::{Stopper, DynStop, Stop, StopExt};
+    ///
+    /// let stop = Stopper::new();
+    /// let dyn_stop: DynStop = stop.into_dyn();
+    /// let clone = dyn_stop.clone(); // cheap Arc increment
+    /// # }
+    /// # #[cfg(not(feature = "alloc"))]
+    /// # fn main() {}
+    /// ```
+    #[cfg(feature = "alloc")]
+    #[inline]
+    fn into_dyn(self) -> DynStop
+    where
+        Self: 'static,
+    {
+        DynStop::new(self)
     }
 
     /// Create a child stop that inherits cancellation from this stop.

--- a/crates/enough-ffi/Cargo.toml
+++ b/crates/enough-ffi/Cargo.toml
@@ -14,6 +14,6 @@ readme = "README.md"
 default = []
 
 [dependencies]
-enough = { version = "0.4", path = "../enough", default-features = false, features = ["std"] }
+enough = { workspace = true, features = ["std"] }
 
 [dev-dependencies]

--- a/crates/enough-tokio/Cargo.toml
+++ b/crates/enough-tokio/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 default = []
 
 [dependencies]
-enough = { version = "0.4", path = "../enough", default-features = false }
+enough = { workspace = true, default-features = false }
 tokio-util = { version = "0.7", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary

Add `DynStop`, a new type wrapping `Arc<dyn Stop + Send + Sync>` that provides:

- **`Clone` via atomic increment** — no heap allocation, no `Clone` bound on `T`
- **TypeId-based nesting prevention** — `DynStop::new(dyn_stop)` collapses instead of double-wrapping
- **`from_arc()` constructor** — zero-cost pointer widening for `Arc<T: Stop>`
- **`active_stop()` inherent method** — collapses to inner concrete type for hot loops
- **`StopExt::into_dyn()`** — ergonomic conversion alongside existing `into_boxed()`

`BoxedStop` is preserved unchanged. `DynStop` is the recommended choice when you need owned, cloneable type erasure.

## DynStop vs BoxedStop

| | `DynStop` | `BoxedStop` |
|---|-----------|-------------|
| Clone | Yes (Arc increment) | No |
| Clone bound on T | Not required | Not required |
| Storage | `Arc<dyn Stop>` | `Box<dyn Stop>` |
| Send to threads | Clone and move | Must wrap in Arc yourself |
| Use case | **Default choice** | When Clone is unwanted |

## Semver

All changes are additive (new type, new method on StopExt). **Fully semver-compatible** (0.4.1 → 0.4.2).

## Test plan

- [x] Basic construction from Unstoppable, Stopper, StopSource
- [x] Clone shares state (cancellation visible through all clones)
- [x] Clone + send to thread
- [x] may_stop() delegates through Arc
- [x] active_stop() returns None for Unstoppable
- [x] active_stop() collapses to inner concrete type for Stopper
- [x] Nesting collapse: DynStop::new(DynStop::new(x)) == DynStop::new(x)
- [x] from_arc() zero-cost pointer widening
- [x] Non-Clone FnStop wrapped without issue (no Clone bound)
- [x] into_dyn() via StopExt
- [x] Send + Sync
- [x] Debug format
- [x] All 306 tests pass

Resolves #2