### PR TITLE
docs: add OR_DO_THIS.md zero-dep cancellation pattern

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "tests/test-ffi",
     "tests/test-codec-mock",
     "tests/test-ergonomics",
+    "tests/test-or-do-this",
 ]
 
 [workspace.package]

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ fn process(data: &[u8], stop: impl Stop) -> Result<(), StopReason> {
 | [`enough-ffi`](https://crates.io/crates/enough-ffi) | C FFI for cross-language use |
 | [`enough-tokio`](https://crates.io/crates/enough-tokio) | Bridge to tokio's CancellationToken |
 
+Can't add a dependency? See [`ZERO-DEP.md`](ZERO-DEP.md).
+
 ## Features
 
 - **None (default)** - `no_std` core: `Stop` trait, `StopReason`, `Unstoppable`

--- a/ZERO-DEP.md
+++ b/ZERO-DEP.md
@@ -1,0 +1,232 @@
+# Zero-Dep Cancellation Pattern Compatible With `enough`
+
+Copy [`tests/test-or-do-this/src/zerodep.rs`](tests/test-or-do-this/src/zerodep.rs)
+into your crate. One file, zero deps, compatible with `enough` in
+both directions.
+
+## The shape
+
+```rust
+pub struct StopCheck {
+    inner: Option<Arc<dyn Fn() -> Result<(), StopReason> + Send + Sync>>,
+}
+```
+
+- `None` is the no-cancel case — zero cost, zero allocations, const.
+- `Some(Arc<dyn Fn>)` captures the caller's cancellation state in a
+  closure. One `Arc` allocation at construction; clone-cheap forever
+  (refcount bump).
+- 16 bytes, niche-optimized. Same memory layout as
+  `enough::StopToken`.
+- `StopReason` matches `enough::StopReason` variant-for-variant
+  (`Cancelled`, `TimedOut`), implements `core::error::Error`.
+
+The full file — including docs — is
+[`tests/test-or-do-this/src/zerodep.rs`](tests/test-or-do-this/src/zerodep.rs).
+Under 300 lines, most of which are docs and doctests. **You copy it
+into your crate and stop thinking about it.**
+
+## Why these exact choices
+
+Each design decision is deliberate. If you deviate, you pay for it:
+
+- **Owned, not borrowed (`StopCheck`, not `StopCheck<'a>`).** Lets
+  you store it in structs and fan it out across threads without
+  lifetime parameters propagating through your entire API.
+- **`'static` closure.** Required for erased storage behind `Arc<dyn Fn>`
+  and for crossing `thread::spawn`. The cost is that your closure
+  can't borrow stack state — but because every real source
+  (`Stopper`, `Arc<AtomicBool>`, `CancellationToken`) is already a
+  clone-cheap handle, you just `move` a clone into the closure.
+- **`Arc`, not `Box`.** `Box<dyn Fn>` isn't `Clone`, so you couldn't
+  fan out a `StopCheck` to multiple threads or stash a copy in a
+  child decoder. `Arc` gets you `Clone` for a single atomic
+  increment.
+- **`Result<(), StopReason>` closure return, not `bool`.** Matches
+  `enough::Stop::check()` exactly, so lossless bridging is
+  `move || token.check().map_err(...)`. A convenience constructor
+  (`from_flag`) covers the common "just a bool" case.
+- **`Send + Sync` on the closure.** Required to make `StopCheck`
+  itself `Send + Sync` — which you need for thread fan-out, rayon
+  parallel iterators, and async tasks.
+
+## Storing it in your types
+
+```rust
+use your_crate::zerodep::{StopCheck, StopReason};
+
+pub struct Decoder {
+    stop: StopCheck,   // no lifetime parameter, no generics
+    block_size: usize,
+}
+
+#[derive(Debug)]
+pub enum DecodeError {
+    Stopped(StopReason),
+    InvalidData,
+}
+
+impl From<StopReason> for DecodeError {
+    fn from(r: StopReason) -> Self { DecodeError::Stopped(r) }
+}
+
+impl Decoder {
+    pub fn new(stop: StopCheck) -> Self {
+        Self { stop, block_size: 1024 }
+    }
+
+    pub fn decode(&self, data: &[u8]) -> Result<Vec<u8>, DecodeError> {
+        let mut out = Vec::with_capacity(data.len());
+        for (i, chunk) in data.chunks(self.block_size).enumerate() {
+            if i % 16 == 0 { self.stop.check()?; }
+            out.extend_from_slice(chunk);
+        }
+        Ok(out)
+    }
+}
+```
+
+## Bridging from every source
+
+One-line bridges from everything:
+
+| Source | Bridge |
+|--------|--------|
+| Nothing | `StopCheck::none()` |
+| `Arc<AtomicBool>` | `StopCheck::from_atomic(flag.clone())` |
+| `enough` (cancel only) | `StopCheck::maybe_flag(stop.may_stop().then(\|\| ...))` |
+| `enough` (reason-preserving) | `StopCheck::maybe(stop.may_stop().then(\|\| ...))` |
+| `tokio_util::CancellationToken` | `StopCheck::from_flag(move \|\| token.is_cancelled())` |
+| `crossbeam_channel::Receiver<()>` | `StopCheck::from_flag(move \|\| rx.try_recv().is_ok())` |
+
+The reason-preserving bridge from `enough` is one `map_reason`
+function you write once per crate, then every bridge is a one-liner:
+
+```rust
+use enough::StopReason as EReason;
+use your_crate::zerodep::StopReason as ZReason;
+
+/// Write once. enough's StopReason is #[non_exhaustive] so
+/// the wildcard arm is required.
+fn map_reason(r: EReason) -> ZReason {
+    match r {
+        EReason::Cancelled => ZReason::Cancelled,
+        EReason::TimedOut  => ZReason::TimedOut,
+        _                  => ZReason::Cancelled, // safe default
+    }
+}
+
+// Then every bridge is this — `maybe` + `then` skips the Arc
+// and the clone when may_stop() is false (e.g. Unstoppable):
+StopCheck::maybe(token.may_stop().then(|| {
+    let t = token.clone();
+    move || t.check().map_err(map_reason)
+}))
+```
+
+## Going the other way: your library calls an `enough`-using crate
+
+Return a `StopToken` — it preserves the `may_stop()` optimization
+in both directions. When `StopCheck` is `none()`, the `StopToken`
+stores `None` internally (zero cost, same as `Unstoppable`):
+
+```rust
+use almost_enough::{FnStop, StopToken, Unstoppable};
+
+fn to_enough_stop(stop: &StopCheck) -> StopToken {
+    if stop.may_stop() {
+        let s = stop.clone();
+        StopToken::new(FnStop::new(move || s.check().is_err()))
+    } else {
+        StopToken::new(Unstoppable)
+    }
+}
+```
+
+`StopToken` is `Clone`, so you can fan the result out to rayon,
+async tasks, or anywhere else. Both adapter directions preserve
+`Clone` and `may_stop()` all the way down to the original flag.
+See the `forward_adapter` and `reverse_adapter` test modules for
+exhaustive validation including cross-thread fan-out and
+`none()` round-trip.
+
+## Naming and collisions
+
+**`StopCheck`** is deliberately *not* called `StopToken` — when both
+are in scope you can tell at a glance which is the closure-backed
+handle and which is the trait-backed one.
+
+**`StopReason`** deliberately *matches* `enough::StopReason` — same
+variant names, so `impl From<StopReason> for MyError` is identical
+for both. When bridging code needs both in scope, alias them:
+
+```rust
+use almost_enough::StopReason as EReason;
+use your_crate::zerodep::StopReason as ZReason;
+```
+
+## Layout and cost
+
+`StopCheck` is 16 bytes:
+
+| Operation | Cost |
+|-----------|------|
+| `StopCheck::none()` | 0 bytes, `const`, zero allocations |
+| `StopCheck::new(f)` / `from_flag(f)` | One `Arc` heap allocation |
+| `.check()` (none) | One perfectly-predicted branch |
+| `.check()` (some) | One branch + one indirect vtable call |
+| `.clone()` | Atomic refcount increment; free for `none()` |
+
+## When to upgrade to `enough`
+
+Both `StopCheck` and `enough` support: reason distinction
+(`Cancelled` / `TimedOut`), `core::error::Error`, clone-cheap
+handles, `'static` storage, closure bridging, and `no_std + alloc`.
+
+What `enough` adds:
+
+| Feature | Crate |
+|---------|-------|
+| Zero-cost `Unstoppable` via generics | `enough` |
+| Hierarchical (parent/child) cancellation | `almost-enough` |
+| Built-in timeout composition | `almost-enough` |
+| Drop guards (cancel-on-drop RAII) | `almost-enough` |
+| `Or`-combinators (stop-if-either) | `almost-enough` |
+| Ready-made bridges (tokio, FFI) | `enough-tokio`, `enough-ffi` |
+
+`StopCheck` is the 80% you can ship in a single file. If you need
+the other 20%, you need a crate — and `enough` is specifically that
+crate.
+
+## Going both ways
+
+You don't have to commit. A library that ships `StopCheck` today can:
+
+- **Add `enough` as a dep later** without breaking its users.
+- **Be called by an `enough` user today** via the forward adapter.
+- **Call an `enough`-using library today** via `FnStop`.
+- **Be copy-pasted into yet another crate** — the file is
+  self-contained and liberal-licensed.
+
+## Validation
+
+32 unit tests + 6 doctests cover standalone use, struct storage,
+bidirectional `enough` interop, `Clone` preservation through the
+full adapter chain, and reason-preserving bridges with actual
+timeout firing. Run them with:
+
+```bash
+cargo test -p test-or-do-this
+```
+
+## Summary
+
+1. Copy [`tests/test-or-do-this/src/zerodep.rs`](tests/test-or-do-this/src/zerodep.rs)
+   into your crate.
+2. Store `StopCheck` in your types. No lifetime parameters.
+3. Call `self.stop.check()?` in your hot loops.
+4. `impl From<StopReason> for YourError`.
+5. Document that your users can bridge from anything.
+
+Your crate is now cancellation-friendly with zero external deps
+and a clear migration path into `enough` if and when you need more.

--- a/tests/test-or-do-this/Cargo.toml
+++ b/tests/test-or-do-this/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "test-or-do-this"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+# The `zerodep` module is the pattern under test. It must remain
+# zero-dep to prove the "copy this file into your crate" story.
+# `almost-enough` is a dev-dep only — used by the bridge tests to
+# validate that enough users and zerodep users can interoperate.
+
+[dependencies]
+
+[dev-dependencies]
+almost-enough = { workspace = true }

--- a/tests/test-or-do-this/src/lib.rs
+++ b/tests/test-or-do-this/src/lib.rs
@@ -1,0 +1,709 @@
+//! Validation crate for the `zerodep` cooperative-cancellation pattern.
+//!
+//! This crate exists to test that the [`zerodep`] module — a zero-dep,
+//! one-file cancellation pattern — actually works in practice:
+//!
+//! 1. Standalone (no cancellation dep at all).
+//! 2. As a drop-in target for `enough` users (forward adapter).
+//! 3. As a client of `enough`-using libraries (reverse adapter).
+//!
+//! The `zerodep` module is what a crate author would copy-paste into
+//! their own crate. This `lib.rs` uses `almost-enough` as a dev-dep
+//! only to prove interop works — `zerodep` itself depends on nothing
+//! beyond `alloc`.
+
+pub mod zerodep;
+
+// ---------------------------------------------------------------------
+// A mock zero-dep decoder. This is what a library that adopts the
+// pattern looks like. No `enough` dep, no trait plumbing — just a
+// stored `StopCheck` and a `self.stop.check()?` call in the hot loop.
+// ---------------------------------------------------------------------
+
+use zerodep::{StopCheck, StopReason};
+
+/// Error type for the mock zero-dep decoder.
+///
+/// Implements `From<StopReason>` so `self.stop.check()?` works
+/// directly and preserves the reason.
+#[derive(Debug, PartialEq, Eq)]
+pub enum DecodeError {
+    Stopped(StopReason),
+    Empty,
+}
+
+impl From<StopReason> for DecodeError {
+    fn from(r: StopReason) -> Self {
+        DecodeError::Stopped(r)
+    }
+}
+
+/// Mock zero-dep decoder. Stores a `StopCheck` — no lifetime
+/// parameter, no viral generics. Checks every 16 chunks.
+pub struct Decoder {
+    stop: StopCheck,
+    block_size: usize,
+    check_frequency: usize,
+}
+
+impl Decoder {
+    pub fn new(stop: StopCheck) -> Self {
+        Self {
+            stop,
+            block_size: 64,
+            check_frequency: 16,
+        }
+    }
+
+    pub fn decode(&self, data: &[u8]) -> Result<Vec<u8>, DecodeError> {
+        if data.is_empty() {
+            return Err(DecodeError::Empty);
+        }
+        let mut out = Vec::with_capacity(data.len());
+        for (i, chunk) in data.chunks(self.block_size).enumerate() {
+            if i % self.check_frequency == 0 {
+                self.stop.check()?;
+            }
+            for &byte in chunk {
+                out.push(byte.wrapping_add(1));
+            }
+        }
+        Ok(out)
+    }
+}
+
+// ---------------------------------------------------------------------
+// Standalone tests — the pattern works with nothing else in scope.
+// ---------------------------------------------------------------------
+
+#[cfg(test)]
+mod standalone {
+    use super::*;
+    use core::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    #[test]
+    fn none_passes_through() {
+        let decoder = Decoder::new(StopCheck::none());
+        let data = vec![0u8; 10_000];
+        assert_eq!(decoder.decode(&data).unwrap().len(), 10_000);
+    }
+
+    #[test]
+    fn none_is_default() {
+        let default: StopCheck = Default::default();
+        assert!(default.check().is_ok());
+        assert!(!default.may_stop());
+    }
+
+    #[test]
+    fn none_is_const() {
+        const NONE: StopCheck = StopCheck::none();
+        assert!(NONE.check().is_ok());
+    }
+
+    #[test]
+    fn from_flag_always_false() {
+        let decoder = Decoder::new(StopCheck::from_flag(|| false));
+        let data = vec![0u8; 10_000];
+        assert_eq!(decoder.decode(&data).unwrap().len(), 10_000);
+    }
+
+    #[test]
+    fn from_flag_always_true_reports_cancelled() {
+        let decoder = Decoder::new(StopCheck::from_flag(|| true));
+        let data = vec![0u8; 10_000];
+        assert_eq!(
+            decoder.decode(&data).unwrap_err(),
+            DecodeError::Stopped(StopReason::Cancelled)
+        );
+    }
+
+    #[test]
+    fn new_with_explicit_reason() {
+        let decoder = Decoder::new(StopCheck::new(|| Err(StopReason::TimedOut)));
+        let data = vec![0u8; 10_000];
+        assert_eq!(
+            decoder.decode(&data).unwrap_err(),
+            DecodeError::Stopped(StopReason::TimedOut)
+        );
+    }
+
+    #[test]
+    fn from_atomic_bridge() {
+        let flag = Arc::new(AtomicBool::new(false));
+        let stop = StopCheck::from_atomic(flag.clone());
+        let decoder = Decoder::new(stop);
+        let data = vec![0u8; 10_000];
+
+        assert!(decoder.decode(&data).is_ok());
+
+        flag.store(true, Ordering::Relaxed);
+        assert_eq!(
+            decoder.decode(&data).unwrap_err(),
+            DecodeError::Stopped(StopReason::Cancelled)
+        );
+    }
+
+    #[test]
+    fn from_atomic_clone_shares_state() {
+        let flag = Arc::new(AtomicBool::new(false));
+        let stop = StopCheck::from_atomic(flag.clone());
+        let clone = stop.clone();
+
+        assert!(stop.check().is_ok());
+        assert!(clone.check().is_ok());
+
+        flag.store(true, Ordering::Relaxed);
+        assert!(stop.check().is_err());
+        assert!(clone.check().is_err());
+    }
+
+    #[test]
+    fn question_mark_ergonomics() {
+        fn worker(stop: &StopCheck) -> Result<(), DecodeError> {
+            for _ in 0..1000 {
+                stop.check()?;
+            }
+            Ok(())
+        }
+
+        assert!(worker(&StopCheck::none()).is_ok());
+
+        let always = StopCheck::from_flag(|| true);
+        assert_eq!(
+            worker(&always).unwrap_err(),
+            DecodeError::Stopped(StopReason::Cancelled)
+        );
+    }
+
+    #[test]
+    fn stop_check_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<StopCheck>();
+        assert_send_sync::<StopReason>();
+    }
+
+    #[test]
+    fn stop_check_is_clone_via_arc() {
+        let flag = Arc::new(AtomicBool::new(false));
+        let stop = StopCheck::from_atomic(flag.clone());
+
+        let clone1 = stop.clone();
+        let clone2 = stop.clone();
+
+        assert!(clone1.check().is_ok());
+        assert!(clone2.check().is_ok());
+
+        flag.store(true, Ordering::Relaxed);
+        assert!(stop.check().is_err());
+        assert!(clone1.check().is_err());
+        assert!(clone2.check().is_err());
+    }
+
+    #[test]
+    fn stop_check_clone_crosses_thread_spawn() {
+        use std::thread;
+
+        let flag = Arc::new(AtomicBool::new(false));
+        let stop = StopCheck::from_atomic(flag.clone());
+
+        let stop_bg = stop.clone();
+        let data = Arc::new(vec![0u8; 1_000_000]);
+        let data_bg = Arc::clone(&data);
+
+        let handle = thread::spawn(move || {
+            let decoder = Decoder::new(stop_bg);
+            for _ in 0..10_000 {
+                match decoder.decode(&data_bg[..100]) {
+                    Ok(_) => continue,
+                    Err(DecodeError::Stopped(r)) => return Err(r),
+                    Err(e) => panic!("unexpected: {:?}", e),
+                }
+            }
+            Ok(())
+        });
+
+        flag.store(true, Ordering::Relaxed);
+        assert_eq!(handle.join().unwrap(), Err(StopReason::Cancelled));
+    }
+
+    #[test]
+    fn stored_in_struct_without_lifetime() {
+        fn take_decoder(_: Decoder) {}
+        fn return_decoder() -> Decoder {
+            Decoder::new(StopCheck::none())
+        }
+        take_decoder(return_decoder());
+    }
+
+    #[test]
+    fn may_stop_semantics() {
+        assert!(!StopCheck::none().may_stop());
+        assert!(StopCheck::from_flag(|| false).may_stop());
+        assert!(StopCheck::from_flag(|| true).may_stop());
+        assert!(StopCheck::new(|| Ok(())).may_stop());
+        assert!(StopCheck::new(|| Err(StopReason::Cancelled)).may_stop());
+        assert!(StopCheck::from_atomic(Arc::new(AtomicBool::new(false))).may_stop());
+    }
+
+    #[test]
+    fn maybe_none_is_none() {
+        let stop = StopCheck::maybe(None::<fn() -> Result<(), StopReason>>);
+        assert!(!stop.may_stop());
+    }
+
+    #[test]
+    fn maybe_flag_none_is_none() {
+        let stop = StopCheck::maybe_flag(None::<fn() -> bool>);
+        assert!(!stop.may_stop());
+    }
+
+    #[test]
+    fn debug_impl_reports_may_stop() {
+        let dbg_none = format!("{:?}", StopCheck::none());
+        assert!(dbg_none.contains("false"));
+
+        let dbg_some = format!("{:?}", StopCheck::from_flag(|| false));
+        assert!(dbg_some.contains("true"));
+    }
+
+    #[test]
+    fn stop_reason_impls_core_error() {
+        fn assert_error<T: core::error::Error>() {}
+        assert_error::<StopReason>();
+
+        let r: StopReason = StopReason::Cancelled;
+        let e: &dyn core::error::Error = &r;
+        assert!(e.source().is_none());
+    }
+
+    #[test]
+    fn stop_reason_display() {
+        assert_eq!(format!("{}", StopReason::Cancelled), "operation cancelled");
+        assert_eq!(format!("{}", StopReason::TimedOut), "operation timed out");
+    }
+
+    #[test]
+    fn stop_reason_match_directly() {
+        #[allow(unreachable_patterns)]
+        fn classify(r: StopReason) -> &'static str {
+            match r {
+                StopReason::Cancelled => "cancelled",
+                StopReason::TimedOut => "timed_out",
+                _ => "unknown",
+            }
+        }
+        assert_eq!(classify(StopReason::Cancelled), "cancelled");
+        assert_eq!(classify(StopReason::TimedOut), "timed_out");
+    }
+}
+
+// ---------------------------------------------------------------------
+// Forward adapter: an `enough` user calls a `zerodep` library.
+// ---------------------------------------------------------------------
+
+#[cfg(test)]
+mod forward_adapter {
+    use super::*;
+    use almost_enough::{Stop, Stopper, TimeoutExt, Unstoppable};
+
+    use almost_enough::StopReason as EReason;
+    use zerodep::StopReason as ZReason;
+
+    #[allow(unreachable_patterns)]
+    fn map_reason(r: EReason) -> ZReason {
+        match r {
+            EReason::Cancelled => ZReason::Cancelled,
+            EReason::TimedOut => ZReason::TimedOut,
+            _ => ZReason::Cancelled,
+        }
+    }
+
+    #[test]
+    fn unstoppable_collapses_to_none() {
+        let stop = Unstoppable;
+        // Unstoppable is Copy/zero-sized, so the closure is trivial.
+        // For Stopper (which needs a clone), use .then(|| { ... }).
+        fn never() -> bool {
+            false
+        }
+        let check = StopCheck::maybe_flag(stop.may_stop().then_some(never as fn() -> bool));
+        assert!(!check.may_stop());
+
+        let decoder = Decoder::new(check);
+        let data = vec![0u8; 10_000];
+        assert!(decoder.decode(&data).is_ok());
+    }
+
+    #[test]
+    fn stopper_bridges_via_maybe_flag() {
+        let stop = Stopper::new();
+        let check = StopCheck::maybe_flag(stop.may_stop().then(|| {
+            let s = stop.clone();
+            move || s.should_stop() // enough's should_stop
+        }));
+        assert!(check.may_stop());
+
+        let decoder = Decoder::new(check);
+        let data = vec![0u8; 10_000];
+        assert!(decoder.decode(&data).is_ok());
+
+        stop.cancel();
+        assert_eq!(
+            decoder.decode(&data).unwrap_err(),
+            DecodeError::Stopped(ZReason::Cancelled)
+        );
+    }
+
+    #[test]
+    fn reason_preserving_bridge_from_enough() {
+        let stop = Stopper::new();
+        let timed = stop
+            .clone()
+            .with_timeout(core::time::Duration::from_secs(60));
+        let check = StopCheck::maybe(timed.may_stop().then(|| {
+            let t = timed.clone();
+            move || t.check().map_err(map_reason)
+        }));
+
+        let decoder = Decoder::new(check);
+        let data = vec![0u8; 10_000];
+
+        assert!(decoder.decode(&data).is_ok());
+
+        stop.cancel();
+        assert_eq!(
+            decoder.decode(&data).unwrap_err(),
+            DecodeError::Stopped(ZReason::Cancelled),
+        );
+    }
+
+    #[test]
+    fn reason_preserving_bridge_timed_out() {
+        use std::thread;
+        use std::time::Duration;
+
+        let stop = Stopper::new();
+        let timed = stop.clone().with_timeout(Duration::from_millis(1));
+        let check = StopCheck::maybe(timed.may_stop().then(|| {
+            let t = timed.clone();
+            move || t.check().map_err(map_reason)
+        }));
+
+        let decoder = Decoder::new(check);
+        let data = vec![0u8; 10_000];
+
+        thread::sleep(Duration::from_millis(10));
+
+        assert_eq!(
+            decoder.decode(&data).unwrap_err(),
+            DecodeError::Stopped(ZReason::TimedOut),
+        );
+    }
+
+    #[test]
+    fn forward_adapter_clone_preserves_state() {
+        let stopper = Stopper::new();
+        let stopper_c = stopper.clone();
+        let check = StopCheck::from_flag(move || stopper_c.should_stop());
+
+        let clone_a = check.clone();
+        let clone_b = check.clone();
+        let clone_of_clone = clone_a.clone();
+
+        assert!(check.check().is_ok());
+        assert!(clone_a.check().is_ok());
+        assert!(clone_b.check().is_ok());
+        assert!(clone_of_clone.check().is_ok());
+
+        stopper.cancel();
+
+        assert!(check.check().is_err());
+        assert!(clone_a.check().is_err());
+        assert!(clone_b.check().is_err());
+        assert_eq!(clone_of_clone.check(), Err(ZReason::Cancelled));
+    }
+
+    #[test]
+    fn forward_adapter_clones_fan_out_to_threads() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::thread;
+        use std::time::Duration;
+
+        let stopper = Stopper::new();
+        let stopper_c = stopper.clone();
+        let check = StopCheck::from_flag(move || stopper_c.should_stop());
+
+        let observed = Arc::new(AtomicUsize::new(0));
+        let handles: Vec<_> = (0..8)
+            .map(|_| {
+                let check_c = check.clone();
+                let observed = Arc::clone(&observed);
+                thread::spawn(move || {
+                    while check_c.check().is_ok() {
+                        thread::yield_now();
+                    }
+                    assert_eq!(check_c.check(), Err(ZReason::Cancelled));
+                    observed.fetch_add(1, Ordering::Relaxed);
+                })
+            })
+            .collect();
+
+        thread::sleep(Duration::from_millis(10));
+        stopper.cancel();
+
+        for h in handles {
+            h.join().unwrap();
+        }
+        assert_eq!(observed.load(Ordering::Relaxed), 8);
+    }
+
+    #[test]
+    fn forward_bridge_crosses_threads() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let stop = Stopper::new();
+        let stop_c = stop.clone();
+        let check = StopCheck::from_flag(move || stop_c.should_stop());
+        let decoder = Arc::new(Decoder::new(check));
+        let data = Arc::new(vec![0u8; 1_000_000]);
+
+        let decoder_bg = Arc::clone(&decoder);
+        let data_bg = Arc::clone(&data);
+        let handle = thread::spawn(move || {
+            for _ in 0..10_000 {
+                match decoder_bg.decode(&data_bg[..100]) {
+                    Ok(_) => continue,
+                    Err(DecodeError::Stopped(r)) => return Err(r),
+                    Err(e) => panic!("unexpected: {:?}", e),
+                }
+            }
+            Ok(())
+        });
+
+        stop.cancel();
+        assert_eq!(handle.join().unwrap(), Err(ZReason::Cancelled));
+    }
+}
+
+// ---------------------------------------------------------------------
+// Reverse adapter: a `zerodep` user calls an `enough`-using library.
+// ---------------------------------------------------------------------
+
+#[cfg(test)]
+mod reverse_adapter {
+    use super::zerodep::{StopCheck, StopReason as ZReason};
+    use almost_enough::StopReason as EReason;
+    use almost_enough::{FnStop, Stop, StopToken, Unstoppable};
+
+    #[allow(unreachable_patterns)]
+    fn map_reason(r: ZReason) -> EReason {
+        match r {
+            ZReason::Cancelled => EReason::Cancelled,
+            ZReason::TimedOut => EReason::TimedOut,
+            _ => EReason::Cancelled,
+        }
+    }
+
+    fn enough_decode(data: &[u8], stop: impl Stop) -> Result<Vec<u8>, EReason> {
+        let mut out = Vec::with_capacity(data.len());
+        for (i, chunk) in data.chunks(64).enumerate() {
+            if i % 16 == 0 {
+                stop.check()?;
+            }
+            out.extend_from_slice(chunk);
+        }
+        Ok(out)
+    }
+
+    /// may_stop()-aware bridge: StopCheck → StopToken.
+    /// Preserves None ↔ Unstoppable round trip.
+    fn to_enough_stop(stop: &StopCheck) -> StopToken {
+        if stop.may_stop() {
+            let s = stop.clone();
+            StopToken::new(FnStop::new(move || s.check().is_err()))
+        } else {
+            StopToken::new(Unstoppable)
+        }
+    }
+
+    #[test]
+    fn zerodep_user_bridges_stopcheck_to_enough() {
+        use core::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        let flag = Arc::new(AtomicBool::new(false));
+        let my_stop = StopCheck::from_atomic(flag.clone());
+        let data = vec![0u8; 10_000];
+
+        let stop_c = my_stop.clone();
+        let bridged = FnStop::new(move || stop_c.check().is_err());
+        assert!(enough_decode(&data, &bridged).is_ok());
+
+        flag.store(true, Ordering::Relaxed);
+        let stop_c = my_stop.clone();
+        let bridged = FnStop::new(move || stop_c.check().is_err());
+        assert_eq!(
+            enough_decode(&data, &bridged).unwrap_err(),
+            EReason::Cancelled
+        );
+    }
+
+    #[test]
+    fn reverse_adapter_helper_function() {
+        use core::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        let flag = Arc::new(AtomicBool::new(false));
+        let my_stop = StopCheck::from_atomic(flag.clone());
+
+        let data = vec![0u8; 10_000];
+        let token = to_enough_stop(&my_stop);
+        assert!(token.may_stop());
+        assert!(enough_decode(&data, &token).is_ok());
+
+        flag.store(true, Ordering::Relaxed);
+        assert_eq!(
+            enough_decode(&data, to_enough_stop(&my_stop)).unwrap_err(),
+            EReason::Cancelled
+        );
+    }
+
+    #[test]
+    fn reverse_adapter_none_preserves_may_stop() {
+        let none = StopCheck::none();
+        assert!(!none.may_stop());
+
+        let token = to_enough_stop(&none);
+        assert!(!token.may_stop());
+        assert!(token.check().is_ok());
+    }
+
+    #[test]
+    fn reason_preserving_reverse_adapter() {
+        struct ReasonPreserving(StopCheck);
+        impl Stop for ReasonPreserving {
+            fn check(&self) -> Result<(), EReason> {
+                self.0.check().map_err(map_reason)
+            }
+        }
+
+        let my_stop = StopCheck::new(|| Err(ZReason::TimedOut));
+        let bridged = ReasonPreserving(my_stop);
+        let data = vec![0u8; 10_000];
+        assert_eq!(
+            enough_decode(&data, &bridged).unwrap_err(),
+            EReason::TimedOut
+        );
+    }
+
+    #[test]
+    fn reverse_adapter_fnstop_is_clone_when_closure_captures_stopcheck() {
+        use core::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        fn assert_clone<T: Clone>(_: &T) {}
+
+        let flag = Arc::new(AtomicBool::new(false));
+        let my_stop = StopCheck::from_atomic(flag.clone());
+
+        let stop_c = my_stop.clone();
+        let bridged = FnStop::new(move || stop_c.check().is_err());
+
+        assert_clone(&bridged);
+
+        let bridged_clone = bridged.clone();
+        let bridged_clone2 = bridged.clone();
+
+        assert!(!bridged.should_stop());
+        assert!(!bridged_clone.should_stop());
+        assert!(!bridged_clone2.should_stop());
+
+        flag.store(true, Ordering::Relaxed);
+
+        assert!(bridged.should_stop());
+        assert!(bridged_clone.should_stop());
+        assert!(bridged_clone2.should_stop());
+    }
+
+    #[test]
+    fn reverse_adapter_fnstop_clones_fan_out_to_threads() {
+        use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+        use std::sync::Arc;
+        use std::thread;
+        use std::time::Duration;
+
+        let flag = Arc::new(AtomicBool::new(false));
+        let my_stop = StopCheck::from_atomic(flag.clone());
+
+        let stop_c = my_stop.clone();
+        let bridged = FnStop::new(move || stop_c.check().is_err());
+
+        let observed = Arc::new(AtomicUsize::new(0));
+        let handles: Vec<_> = (0..8)
+            .map(|_| {
+                let b = bridged.clone();
+                let observed = Arc::clone(&observed);
+                thread::spawn(move || {
+                    let data = vec![0u8; 100];
+                    loop {
+                        match enough_decode(&data, &b) {
+                            Ok(_) => thread::yield_now(),
+                            Err(EReason::Cancelled) => {
+                                observed.fetch_add(1, Ordering::Relaxed);
+                                return;
+                            }
+                            Err(other) => panic!("unexpected: {:?}", other),
+                        }
+                    }
+                })
+            })
+            .collect();
+
+        thread::sleep(Duration::from_millis(10));
+        flag.store(true, Ordering::Relaxed);
+
+        for h in handles {
+            h.join().unwrap();
+        }
+        assert_eq!(observed.load(Ordering::Relaxed), 8);
+    }
+
+    #[test]
+    fn reverse_adapter_clone_chain_preserves_state() {
+        use core::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        let flag = Arc::new(AtomicBool::new(false));
+        let stop = StopCheck::from_atomic(flag.clone());
+        let stop_clone = stop.clone();
+        let fn_stop = FnStop::new(move || stop_clone.check().is_err());
+        let fn_stop_clone = fn_stop.clone();
+
+        assert!(stop.check().is_ok());
+        assert!(!fn_stop.should_stop());
+        assert!(!fn_stop_clone.should_stop());
+
+        flag.store(true, Ordering::Relaxed);
+
+        assert!(stop.check().is_err());
+        assert!(fn_stop.should_stop());
+        assert!(fn_stop_clone.should_stop());
+
+        flag.store(false, Ordering::Relaxed);
+        assert!(stop.check().is_ok());
+        assert!(!fn_stop.should_stop());
+        assert!(!fn_stop_clone.should_stop());
+    }
+
+    #[test]
+    fn none_stopcheck_bridges_to_fnstop() {
+        let my_stop = StopCheck::none();
+        let bridged = FnStop::new(move || my_stop.check().is_err());
+        let data = vec![0u8; 1000];
+        assert!(enough_decode(&data, &bridged).is_ok());
+    }
+}

--- a/tests/test-or-do-this/src/zerodep.rs
+++ b/tests/test-or-do-this/src/zerodep.rs
@@ -1,0 +1,326 @@
+//! Zero-dependency cooperative cancellation — owned, storable, clone-cheap.
+//!
+//! **Copy this single file into your crate** to support cooperative
+//! cancellation without taking a dependency on `enough` (or anything
+//! else). [`StopCheck`] is an owned, `'static`, clone-cheap handle
+//! you can drop into any struct without propagating lifetime
+//! parameters.
+//!
+//! Callers using `enough`, a raw `AtomicBool`, tokio's
+//! `CancellationToken`, or any other source bridge in a single
+//! closure. Only dependency: `alloc::sync::Arc` (so `no_std + alloc`
+//! is fine; pure `no_std` is not).
+//!
+//! # Example
+//!
+//! ```rust
+//! # use test_or_do_this::zerodep::{StopCheck, StopReason};
+//! pub struct Decoder {
+//!     stop: StopCheck,
+//!     block_size: usize,
+//! }
+//!
+//! #[derive(Debug)]
+//! pub enum DecodeError {
+//!     Stopped(StopReason),
+//!     InvalidData,
+//! }
+//!
+//! impl From<StopReason> for DecodeError {
+//!     fn from(r: StopReason) -> Self { DecodeError::Stopped(r) }
+//! }
+//!
+//! impl Decoder {
+//!     pub fn new(stop: StopCheck) -> Self {
+//!         Self { stop, block_size: 1024 }
+//!     }
+//!
+//!     pub fn decode(&self, data: &[u8]) -> Result<Vec<u8>, DecodeError> {
+//!         let mut out = Vec::with_capacity(data.len());
+//!         for (i, chunk) in data.chunks(self.block_size).enumerate() {
+//!             if i % 16 == 0 { self.stop.check()?; }
+//!             out.extend_from_slice(chunk);
+//!         }
+//!         Ok(out)
+//!     }
+//! }
+//! ```
+//!
+//! # Call sites
+//!
+//! ```rust,ignore
+//! // No cancellation — zero cost, no allocation.
+//! Decoder::new(StopCheck::none())
+//!
+//! // Arc<AtomicBool> — one call, assumes Relaxed + Cancelled:
+//! Decoder::new(StopCheck::from_atomic(flag.clone()))
+//!
+//! // enough — lossless bridge with may_stop() optimization:
+//! Decoder::new(StopCheck::maybe(token.may_stop().then(|| {
+//!     let t = token.clone();
+//!     move || t.check().map_err(map_reason)
+//! })))
+//!
+//! // tokio-util:
+//! let t = cancel_token.clone();
+//! Decoder::new(StopCheck::from_flag(move || t.is_cancelled()))
+//! ```
+//!
+//! # Layout and cost
+//!
+//! [`StopCheck`] is 16 bytes (niche-optimized `Option<Arc<dyn>>` —
+//! `None` is two nulls, `Some` is a fat pointer).
+//!
+//! - `StopCheck::none()` — zero allocations, `check()` is one
+//!   perfectly-predicted branch that returns `Ok(())`.
+//! - `StopCheck::new(f)` / `from_flag(f)` / `from_atomic(flag)` —
+//!   one `Arc` allocation. Never reallocates.
+//! - `check()` — one branch + one indirect call through the vtable
+//!   when `Some`; one branch when `None`.
+//! - [`Clone`] — atomic refcount increment (free for `None`).
+//!
+//! Same shape as `enough::StopToken`, backed by a closure instead of
+//! a trait object so any cancellation source becomes a one-line bridge.
+//!
+//! # `no_std`
+//!
+//! Requires `alloc` (for `Arc`). Add `extern crate alloc;` to your
+//! crate root if you're `no_std`. [`StopReason`] implements
+//! [`core::error::Error`] unconditionally — no `std` feature needed.
+
+#![allow(dead_code)]
+
+extern crate alloc;
+use alloc::sync::Arc;
+use core::fmt;
+use core::sync::atomic::{AtomicBool, Ordering};
+
+/// Owned cooperative-cancellation check.
+///
+/// Clone-cheap (refcount), storable (`'static`, no lifetimes), and
+/// bridgeable from any cancellation source via a closure. See the
+/// [module docs](self) for the full pattern.
+#[derive(Clone, Default)]
+pub struct StopCheck {
+    inner: Option<Arc<dyn Fn() -> Result<(), StopReason> + Send + Sync>>,
+}
+
+impl StopCheck {
+    /// A `StopCheck` that never fires. No allocation, no runtime cost.
+    ///
+    /// This is the default value and is `const`, so it can be used
+    /// in `const` contexts:
+    ///
+    /// ```rust
+    /// # use test_or_do_this::zerodep::StopCheck;
+    /// const NONE: StopCheck = StopCheck::none();
+    /// assert!(NONE.check().is_ok());
+    /// ```
+    #[inline]
+    pub const fn none() -> Self {
+        Self { inner: None }
+    }
+
+    /// Wrap a reason-aware closure.
+    ///
+    /// The closure returns `Ok(())` to keep going, or
+    /// `Err(reason)` to stop. This matches the return type of
+    /// `enough::Stop::check()` exactly, so lossless bridging from
+    /// `enough` sources is a single `move || token.check().map_err(...)`.
+    /// Use [`from_flag`](Self::from_flag) or [`from_atomic`](Self::from_atomic)
+    /// for the common bool-flag case.
+    ///
+    /// One `Arc` allocation, then clone-cheap forever.
+    ///
+    /// ```rust
+    /// # use test_or_do_this::zerodep::{StopCheck, StopReason};
+    /// let stop = StopCheck::new(|| Err(StopReason::TimedOut));
+    /// assert_eq!(stop.check(), Err(StopReason::TimedOut));
+    /// ```
+    #[inline]
+    pub fn new<F>(f: F) -> Self
+    where
+        F: Fn() -> Result<(), StopReason> + Send + Sync + 'static,
+    {
+        Self {
+            inner: Some(Arc::new(f)),
+        }
+    }
+
+    /// Wrap a bool-returning closure; fires with [`StopReason::Cancelled`]
+    /// when it returns `true`.
+    ///
+    /// ```rust
+    /// # use test_or_do_this::zerodep::{StopCheck, StopReason};
+    /// let stop = StopCheck::from_flag(|| true);
+    /// assert_eq!(stop.check(), Err(StopReason::Cancelled));
+    /// ```
+    #[inline]
+    pub fn from_flag<F>(f: F) -> Self
+    where
+        F: Fn() -> bool + Send + Sync + 'static,
+    {
+        Self::new(move || {
+            if f() {
+                Err(StopReason::Cancelled)
+            } else {
+                Ok(())
+            }
+        })
+    }
+
+    /// Wrap an `Arc<AtomicBool>` — fires with [`StopReason::Cancelled`]
+    /// when the flag is `true`. Uses `Relaxed` ordering.
+    ///
+    /// This is the most common "I just want a cancel button" pattern.
+    /// For `Acquire` ordering or a different reason, use
+    /// [`from_flag`](Self::from_flag) with your own closure.
+    ///
+    /// ```rust
+    /// # use test_or_do_this::zerodep::{StopCheck, StopReason};
+    /// use core::sync::atomic::AtomicBool;
+    /// use std::sync::Arc;
+    ///
+    /// let flag = Arc::new(AtomicBool::new(false));
+    /// let stop = StopCheck::from_atomic(flag.clone());
+    ///
+    /// assert!(stop.check().is_ok());
+    /// flag.store(true, core::sync::atomic::Ordering::Relaxed);
+    /// assert_eq!(stop.check(), Err(StopReason::Cancelled));
+    /// ```
+    #[inline]
+    pub fn from_atomic(flag: Arc<AtomicBool>) -> Self {
+        Self::from_flag(move || flag.load(Ordering::Relaxed))
+    }
+
+    /// Like [`new`](Self::new), but `None` collapses to
+    /// [`StopCheck::none()`] — skipping the `Arc` allocation entirely.
+    ///
+    /// Pairs naturally with `bool::then` to bridge from sources that
+    /// have a `may_stop()` method:
+    ///
+    /// ```rust,ignore
+    /// StopCheck::maybe(token.may_stop().then(|| {
+    ///     let t = token.clone();
+    ///     move || t.check().map_err(map_reason)
+    /// }))
+    /// ```
+    #[inline]
+    pub fn maybe<F>(f: Option<F>) -> Self
+    where
+        F: Fn() -> Result<(), StopReason> + Send + Sync + 'static,
+    {
+        match f {
+            Some(f) => Self::new(f),
+            None => Self::none(),
+        }
+    }
+
+    /// Like [`from_flag`](Self::from_flag), but `None` collapses to
+    /// [`StopCheck::none()`].
+    ///
+    /// ```rust,ignore
+    /// StopCheck::maybe_flag(stop.may_stop().then(|| {
+    ///     let s = stop.clone();
+    ///     move || s.check().is_err()
+    /// }))
+    /// ```
+    #[inline]
+    pub fn maybe_flag<F>(f: Option<F>) -> Self
+    where
+        F: Fn() -> bool + Send + Sync + 'static,
+    {
+        match f {
+            Some(f) => Self::from_flag(f),
+            None => Self::none(),
+        }
+    }
+
+    /// Returns `Err(reason)` if the check fires, `Ok(())` otherwise.
+    ///
+    /// Use with `?` in hot loops; implement `From<StopReason>` for
+    /// your error type so this plumbs through naturally.
+    #[inline]
+    pub fn check(&self) -> Result<(), StopReason> {
+        match &self.inner {
+            Some(f) => f(),
+            None => Ok(()),
+        }
+    }
+
+    /// Returns `true` if this check could ever fire.
+    ///
+    /// [`StopCheck::none()`] returns `false` — use this to skip
+    /// cancellation checks entirely in very hot loops:
+    ///
+    /// ```rust
+    /// # use test_or_do_this::zerodep::StopCheck;
+    /// fn hot_loop(stop: &StopCheck) {
+    ///     if stop.may_stop() {
+    ///         // slow path — check periodically
+    ///     } else {
+    ///         // fast path — skip checks entirely
+    ///     }
+    /// }
+    /// ```
+    #[inline]
+    pub fn may_stop(&self) -> bool {
+        self.inner.is_some()
+    }
+}
+
+impl fmt::Debug for StopCheck {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StopCheck")
+            .field("may_stop", &self.may_stop())
+            .finish()
+    }
+}
+
+/// Why an operation was stopped.
+///
+/// Matches the variants and semantics of `enough::StopReason` so
+/// error-type impls are trivially portable between the two.
+///
+/// Implement `From<StopReason>` for your error type to use `?`
+/// naturally with [`StopCheck::check`]:
+///
+/// ```rust
+/// # use test_or_do_this::zerodep::StopReason;
+/// #[derive(Debug)]
+/// enum MyError {
+///     Stopped(StopReason),
+///     Io,
+/// }
+///
+/// impl From<StopReason> for MyError {
+///     fn from(r: StopReason) -> Self { MyError::Stopped(r) }
+/// }
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum StopReason {
+    /// Operation was explicitly cancelled.
+    Cancelled,
+    /// Operation exceeded its deadline.
+    TimedOut,
+}
+
+// Intentionally no `is_cancelled` / `is_timed_out` / `is_transient`
+// helpers. `StopReason` is `#[non_exhaustive]`; match on it directly
+// so future variants produce a compiler error at the match site
+// instead of silently returning `false` from an `is_*` helper.
+
+impl fmt::Display for StopReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Cancelled => f.write_str("operation cancelled"),
+            Self::TimedOut => f.write_str("operation timed out"),
+        }
+    }
+}
+
+// `core::error::Error` is stable since Rust 1.81 — no `std` feature
+// gate needed. The default `source()` returning `None` is correct for
+// a leaf error type.
+impl core::error::Error for StopReason {}


### PR DESCRIPTION
## Summary

- Adds `OR_DO_THIS.md` — a one-file, zero-dep cooperative cancellation
  pattern for crates that can't or won't take the `enough` dep. Same
  `Option<Arc<dyn Fn>>` shape as `enough::StopToken`, closure-backed so
  any source (`AtomicBool`, tokio `CancellationToken`, `enough::Stopper`,
  channels, TLS) bridges in one line. `StopReason` matches `enough`'s
  variant names so `impl From<StopReason>` is portable.
- Adds `tests/test-or-do-this/` — a validation crate containing the
  copy-pasteable `zerodep.rs` file and 32 unit + 6 doctests that lock
  in every claim in the document.
- Naming note: `StopCheck` deliberately differs from `StopToken` to
  disambiguate closure-backed vs trait-backed representations when
  both crates are in scope. `StopReason` deliberately matches so
  error-type impls port without churn.

## What's validated

- Standalone use — `none()`, `new()`, `from_flag()`, `check()?`,
  `Clone`, `Send + Sync`, const-ness, `core::error::Error`.
- Storage without lifetime parameters (no viral `Decoder<'a>`).
- Forward adapter (`enough` user calls `StopCheck`-taking lib) via
  closure, with both `from_flag` and reason-preserving `new` paths.
- Reverse adapter (`StopCheck` holder calls `enough`-using lib) via
  `almost_enough::FnStop`, including a reason-preserving manual
  `Stop` impl.
- `Clone` preserved through the full chain both directions, with a
  compile-time assertion that `FnStop<move-closure capturing StopCheck>`
  is `Clone`.
- Reason preservation for both `Cancelled` and `TimedOut`, including
  actual timeout firing via `TimeoutExt::with_timeout`.

## Test plan

- [x] `cargo test -p test-or-do-this` — 32 unit + 6 doctests, all pass
- [x] `cargo clippy -p test-or-do-this --all-targets -- -D warnings` — clean
- [ ] CI green across all platforms (Linux, macOS Intel, macOS aarch64, Windows, `windows-11-arm`, `i686-unknown-linux-gnu`)