### PR TITLE
feat: lower MSRV from 1.89 to 1.85

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,26 @@ jobs:
 
       - name: Test
         run: cargo test --workspace
+        if: matrix.rust == 'stable'
+
+      # MSRV: criterion 0.8 requires 1.86, so test per-crate to skip bench deps
+      - name: Test MSRV
+        run: |
+          cargo test -p enough
+          cargo test -p almost-enough
+          cargo test -p enough-ffi
+          cargo test -p enough-tokio
+          cargo test -p test-basic
+          cargo test -p test-atomic
+          cargo test -p test-timeout
+          cargo test -p test-child
+          cargo test -p test-rayon
+          cargo test -p test-tokio
+          cargo test -p test-ffi
+          cargo test -p test-codec-mock
+          cargo test -p test-ergonomics
+          cargo test -p test-or-do-this
+        if: matrix.rust != 'stable'
 
       - name: Test (no default features)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        rust: [stable, 1.89]
+        rust: [stable, 1.85]
         exclude:
           # MSRV only on Linux
           - os: windows-latest
-            rust: 1.89
+            rust: 1.85
           - os: macos-latest
-            rust: 1.89
+            rust: 1.85
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,25 +36,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Test (default features)
+      - name: Test
         run: cargo test --workspace
-        if: matrix.rust == 'stable'
-
-      # MSRV: test core crates only (test-rayon requires rayon-core 1.13 which needs Rust 1.80)
-      - name: Test MSRV (core crates)
-        run: |
-          cargo test -p enough
-          cargo test -p almost-enough
-          cargo test -p enough-ffi
-          cargo test -p enough-tokio
-          cargo test -p test-basic
-          cargo test -p test-atomic
-          cargo test -p test-timeout
-          cargo test -p test-child
-          cargo test -p test-tokio
-          cargo test -p test-ffi
-          cargo test -p test-codec-mock
-        if: matrix.rust != 'stable'
 
       - name: Test (no default features)
         run: |
@@ -77,6 +60,8 @@ jobs:
             target: aarch64-unknown-linux-gnu
           - os: windows-11-arm
             target: aarch64-pc-windows-msvc
+          - os: macos-26-intel
+            target: x86_64-apple-darwin
 
     steps:
       - uses: actions/checkout@v6
@@ -113,8 +98,11 @@ jobs:
       - name: Test (i686/QEMU)
         run: cross test --workspace --target i686-unknown-linux-gnu
 
+  # ==========================================================================
+  # no_std and WASM build verification
+  # ==========================================================================
   no-std:
-    name: no_std build
+    name: no_std / WASM
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -122,7 +110,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: thumbv7em-none-eabihf
+          targets: thumbv7em-none-eabihf, wasm32-unknown-unknown
 
       - uses: Swatinem/rust-cache@v2
 
@@ -131,6 +119,97 @@ jobs:
 
       - name: Build no_std (almost-enough)
         run: cargo build -p almost-enough --target thumbv7em-none-eabihf --no-default-features
+
+      - name: Build WASM (enough)
+        run: cargo build -p enough --target wasm32-unknown-unknown --no-default-features --features alloc
+
+      - name: Build WASM (almost-enough)
+        run: cargo build -p almost-enough --target wasm32-unknown-unknown --no-default-features --features alloc
+
+  # ==========================================================================
+  # Feature powerset — verify all feature combinations compile
+  # ==========================================================================
+  features:
+    name: Feature powerset
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Check feature powerset
+        run: cargo hack check --feature-powerset --no-dev-deps -p enough -p almost-enough
+
+  # ==========================================================================
+  # Semver — catch accidental breaking changes
+  # ==========================================================================
+  semver:
+    name: Semver
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-semver-checks
+        uses: taiki-e/install-action@cargo-semver-checks
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Check semver (enough)
+        run: cargo semver-checks -p enough
+
+      - name: Check semver (almost-enough)
+        run: cargo semver-checks -p almost-enough
+
+  # ==========================================================================
+  # Miri — check unsafe code soundness (enough-ffi)
+  # ==========================================================================
+  miri:
+    name: Miri
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust nightly + Miri
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: miri
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run Miri (enough-ffi)
+        run: cargo +nightly miri test -p enough-ffi
+        env:
+          MIRIFLAGS: -Zmiri-strict-provenance
+
+  # ==========================================================================
+  # Dependency audit — licenses and advisories
+  # ==========================================================================
+  deny:
+    name: Deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@cargo-deny
+
+      - name: Check advisories
+        run: cargo deny check advisories
+
+      - name: Check licenses
+        run: cargo deny check licenses
+
+      - name: Check bans
+        run: cargo deny check bans
 
   lint:
     name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,26 +38,6 @@ jobs:
 
       - name: Test
         run: cargo test --workspace
-        if: matrix.rust == 'stable'
-
-      # MSRV: criterion 0.8 requires 1.86, so test per-crate to skip bench deps
-      - name: Test MSRV
-        run: |
-          cargo test -p enough
-          cargo test -p almost-enough
-          cargo test -p enough-ffi
-          cargo test -p enough-tokio
-          cargo test -p test-basic
-          cargo test -p test-atomic
-          cargo test -p test-timeout
-          cargo test -p test-child
-          cargo test -p test-rayon
-          cargo test -p test-tokio
-          cargo test -p test-ffi
-          cargo test -p test-codec-mock
-          cargo test -p test-ergonomics
-          cargo test -p test-or-do-this
-        if: matrix.rust != 'stable'
 
       - name: Test (no default features)
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 [workspace.package]
 version = "0.4.3"
 edition = "2024"
-rust-version = "1.89"
+rust-version = "1.85"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/imazen/enough"
 keywords = ["cancellation", "cooperative", "async", "ffi", "no_std"]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Minimal cooperative cancellation trait for Rust.
 [![docs.rs](https://img.shields.io/docsrs/enough?style=flat-square)](https://docs.rs/enough)
 [![codecov](https://img.shields.io/codecov/c/github/imazen/enough?style=flat-square)](https://codecov.io/gh/imazen/enough)
 [![License](https://img.shields.io/crates/l/enough.svg?style=flat-square)](LICENSE-MIT)
-[![MSRV](https://img.shields.io/badge/MSRV-1.89-blue.svg?style=flat-square)](https://blog.rust-lang.org/2025/05/15/Rust-1.89.0.html)
+[![MSRV](https://img.shields.io/badge/MSRV-1.85-blue.svg?style=flat-square)](https://blog.rust-lang.org/2025/02/20/Rust-1.85.0.html)
 
 A `no_std`, zero-dependency trait for cooperative cancellation.
 

--- a/crates/almost-enough/Cargo.toml
+++ b/crates/almost-enough/Cargo.toml
@@ -18,7 +18,6 @@ std = ["alloc"]
 enough = { workspace = true, default-features = false }
 
 [dev-dependencies]
-criterion = { version = "0.8", default-features = false }
 zenbench = { workspace = true }
 
 [[bench]]

--- a/crates/almost-enough/benches/stop_check.rs
+++ b/crates/almost-enough/benches/stop_check.rs
@@ -1,157 +1,20 @@
+//! Per-type cancellation check benchmarks.
+//!
+//! Measures the raw check() cost for every Stop implementation and
+//! dispatch path. Complements stop_check_zen (which focuses on
+//! codec-realistic, layout-immune comparisons) with isolated per-type
+//! measurements including types not covered there (StopRef, ChildStopper,
+//! OrStop, WithTimeout).
+//!
+//! Run with: cargo bench --bench stop_check
+
 use std::hint::black_box;
 use std::time::Duration;
 
 use almost_enough::{
-    ChildStopper, FnStop, OrStop, Stop, StopExt, StopSource, Stopper, SyncStopper, TimeoutExt,
-    Unstoppable, WithTimeout,
+    ChildStopper, FnStop, OrStop, Stop, StopExt, StopReason, StopSource, Stopper, SyncStopper,
+    TimeoutExt, Unstoppable, WithTimeout,
 };
-use criterion::{Criterion, criterion_group, criterion_main};
-
-// ── Group: check (hot path, not cancelled) ──────────────────────────
-
-fn bench_check(c: &mut Criterion) {
-    let mut g = c.benchmark_group("check");
-
-    g.bench_function("unstoppable", |b| {
-        let stop = Unstoppable;
-        b.iter(|| black_box(&stop).check())
-    });
-
-    g.bench_function("stop_source", |b| {
-        let stop = StopSource::new();
-        b.iter(|| black_box(&stop).check())
-    });
-
-    g.bench_function("stop_ref", |b| {
-        let source = StopSource::new();
-        let stop = source.as_ref();
-        b.iter(|| black_box(&stop).check())
-    });
-
-    g.bench_function("stopper", |b| {
-        let stop = Stopper::new();
-        b.iter(|| black_box(&stop).check())
-    });
-
-    g.bench_function("sync_stopper", |b| {
-        let stop = SyncStopper::new();
-        b.iter(|| black_box(&stop).check())
-    });
-
-    g.bench_function("fn_stop", |b| {
-        let stop = FnStop::new(|| false);
-        b.iter(|| black_box(&stop).check())
-    });
-
-    g.bench_function("boxed_stopper", |b| {
-        let stop = Stopper::new().into_boxed();
-        b.iter(|| black_box(&stop).check())
-    });
-
-    g.bench_function("dyn_stopper", |b| {
-        let stop = Stopper::new().into_token();
-        b.iter(|| black_box(&stop).check())
-    });
-
-    g.bench_function("or_stop", |b| {
-        let a = StopSource::new();
-        let b_src = StopSource::new();
-        let stop: OrStop<_, _> = a.as_ref().or(b_src.as_ref());
-        b.iter(|| black_box(&stop).check())
-    });
-
-    g.bench_function("child_depth_1", |b| {
-        let parent = ChildStopper::new();
-        let stop = parent.child();
-        b.iter(|| black_box(&stop).check())
-    });
-
-    g.bench_function("child_depth_3", |b| {
-        let g0 = ChildStopper::new();
-        let g1 = g0.child();
-        let g2 = g1.child();
-        let stop = g2.child();
-        b.iter(|| black_box(&stop).check())
-    });
-
-    g.bench_function("with_timeout", |b| {
-        let source = StopSource::new();
-        let stop: WithTimeout<_> = source.as_ref().with_timeout(Duration::from_secs(3600));
-        b.iter(|| black_box(&stop).check())
-    });
-
-    g.finish();
-}
-
-// ── Group: dispatch (generic vs dyn vs StopToken) ─────────────────────
-
-#[inline(never)]
-fn check_generic(stop: &impl Stop) -> Result<(), almost_enough::StopReason> {
-    stop.check()
-}
-
-#[inline(never)]
-fn check_dyn(stop: &dyn Stop) -> Result<(), almost_enough::StopReason> {
-    stop.check()
-}
-
-fn bench_dispatch(c: &mut Criterion) {
-    let mut g = c.benchmark_group("dispatch");
-
-    g.bench_function("stopper_generic", |b| {
-        let stop = Stopper::new();
-        b.iter(|| check_generic(black_box(&stop)))
-    });
-
-    g.bench_function("stopper_dyn", |b| {
-        let stop = Stopper::new();
-        b.iter(|| check_dyn(black_box(&stop)))
-    });
-
-    g.bench_function("stopper_dynstop", |b| {
-        let stop = Stopper::new().into_token();
-        b.iter(|| black_box(&stop).check())
-    });
-
-    g.bench_function("stopper_dynstop_as_dyn", |b| {
-        let stop = Stopper::new().into_token();
-        b.iter(|| check_dyn(black_box(&stop) as &dyn Stop))
-    });
-
-    g.bench_function("unstoppable_generic", |b| {
-        let stop = Unstoppable;
-        b.iter(|| check_generic(black_box(&stop)))
-    });
-
-    g.bench_function("unstoppable_dyn", |b| {
-        let stop = Unstoppable;
-        b.iter(|| check_dyn(black_box(&stop)))
-    });
-
-    g.finish();
-}
-
-// ── Group: check_cancelled (error return path) ──────────────────────
-
-fn bench_check_cancelled(c: &mut Criterion) {
-    let mut g = c.benchmark_group("check_cancelled");
-
-    g.bench_function("stopper", |b| {
-        let stop = Stopper::cancelled();
-        b.iter(|| black_box(&stop).check())
-    });
-
-    g.bench_function("sync_stopper", |b| {
-        let stop = SyncStopper::cancelled();
-        b.iter(|| black_box(&stop).check())
-    });
-
-    g.finish();
-}
-
-// ── Group: hot_loop (impl Stop vs dyn Stop vs StopToken) ──────────────
-// Proves that impl Stop inlining is negligible vs dyn dispatch in
-// realistic loops with work between checks.
 
 const HOT_LOOP_ITERS: usize = 10_000;
 const CHECK_INTERVAL: usize = 64;
@@ -161,141 +24,292 @@ fn trivial_work(i: usize) -> usize {
     black_box(i.wrapping_mul(2654435761))
 }
 
-/// Inline hot loop — each closure contains the full loop body so the
-/// compiler sees the concrete type directly. No macro, no helper function.
-fn bench_hot_loop(c: &mut Criterion) {
-    let mut g = c.benchmark_group("hot_loop_stopper");
-
-    g.bench_function("impl_stop", |b| {
-        let stop = Stopper::new();
-        b.iter(|| {
-            let mut acc = 0usize;
-            for i in 0..HOT_LOOP_ITERS {
-                if i % CHECK_INTERVAL == 0 {
-                    let _ = stop.check();
-                }
-                acc = acc.wrapping_add(trivial_work(i));
-            }
-            black_box(acc)
-        })
-    });
-
-    g.bench_function("stoptoken", |b| {
-        let stop = Stopper::new().into_token();
-        b.iter(|| {
-            let mut acc = 0usize;
-            for i in 0..HOT_LOOP_ITERS {
-                if i % CHECK_INTERVAL == 0 {
-                    let _ = stop.check();
-                }
-                acc = acc.wrapping_add(trivial_work(i));
-            }
-            black_box(acc)
-        })
-    });
-
-    g.bench_function("dyn_may_stop", |b| {
-        let stop = Stopper::new();
-        let stop: &dyn Stop = &stop;
-        let stop = stop.may_stop().then_some(stop);
-        b.iter(|| {
-            let mut acc = 0usize;
-            for i in 0..HOT_LOOP_ITERS {
-                if i % CHECK_INTERVAL == 0 {
-                    let _ = stop.check();
-                }
-                acc = acc.wrapping_add(trivial_work(i));
-            }
-            black_box(acc)
-        })
-    });
-
-    g.bench_function("dyn_raw", |b| {
-        let stop = Stopper::new();
-        let stop: &dyn Stop = &stop;
-        b.iter(|| {
-            let mut acc = 0usize;
-            for i in 0..HOT_LOOP_ITERS {
-                if i % CHECK_INTERVAL == 0 {
-                    let _ = stop.check();
-                }
-                acc = acc.wrapping_add(trivial_work(i));
-            }
-            black_box(acc)
-        })
-    });
-
-    g.finish();
-
-    let mut g = c.benchmark_group("hot_loop_unstoppable");
-
-    g.bench_function("impl_stop", |b| {
-        let stop = Unstoppable;
-        b.iter(|| {
-            let mut acc = 0usize;
-            for i in 0..HOT_LOOP_ITERS {
-                if i % CHECK_INTERVAL == 0 {
-                    let _ = stop.check();
-                }
-                acc = acc.wrapping_add(trivial_work(i));
-            }
-            black_box(acc)
-        })
-    });
-
-    g.bench_function("stoptoken", |b| {
-        let stop = Unstoppable.into_token();
-        b.iter(|| {
-            let mut acc = 0usize;
-            for i in 0..HOT_LOOP_ITERS {
-                if i % CHECK_INTERVAL == 0 {
-                    let _ = stop.check();
-                }
-                acc = acc.wrapping_add(trivial_work(i));
-            }
-            black_box(acc)
-        })
-    });
-
-    g.bench_function("dyn_may_stop", |b| {
-        let stop = Unstoppable;
-        let stop: &dyn Stop = &stop;
-        let stop = stop.may_stop().then_some(stop);
-        b.iter(|| {
-            let mut acc = 0usize;
-            for i in 0..HOT_LOOP_ITERS {
-                if i % CHECK_INTERVAL == 0 {
-                    let _ = stop.check();
-                }
-                acc = acc.wrapping_add(trivial_work(i));
-            }
-            black_box(acc)
-        })
-    });
-
-    g.bench_function("dyn_raw", |b| {
-        let stop = Unstoppable;
-        let stop: &dyn Stop = &stop;
-        b.iter(|| {
-            let mut acc = 0usize;
-            for i in 0..HOT_LOOP_ITERS {
-                if i % CHECK_INTERVAL == 0 {
-                    let _ = stop.check();
-                }
-                acc = acc.wrapping_add(trivial_work(i));
-            }
-            black_box(acc)
-        })
-    });
-
-    g.finish();
+#[inline(never)]
+fn check_generic(stop: &impl Stop) -> Result<(), StopReason> {
+    stop.check()
 }
 
-criterion_group!(
-    benches,
-    bench_check,
-    bench_dispatch,
-    bench_check_cancelled,
-    bench_hot_loop
-);
-criterion_main!(benches);
+#[inline(never)]
+fn check_dyn(stop: &dyn Stop) -> Result<(), StopReason> {
+    stop.check()
+}
+
+fn main() {
+    let result = zenbench::run(|suite| {
+        // ═══════════════════════════════════════════════════════════
+        // 1. Per-type check() cost (hot path, not cancelled)
+        // ═══════════════════════════════════════════════════════════
+
+        suite.compare("check", |group| {
+            group.config().sort_by_speed(true).cache_firewall(false);
+            group.baseline("unstoppable");
+
+            group.bench("unstoppable", |b| {
+                let stop = Unstoppable;
+                b.iter(|| black_box(&stop).check())
+            });
+
+            group.bench("stop_source", |b| {
+                let stop = StopSource::new();
+                b.iter(|| black_box(&stop).check())
+            });
+
+            group.bench("stop_ref", |b| {
+                let source = StopSource::new();
+                let stop = source.as_ref();
+                b.iter(|| black_box(&stop).check())
+            });
+
+            group.bench("stopper", |b| {
+                let stop = Stopper::new();
+                b.iter(|| black_box(&stop).check())
+            });
+
+            group.bench("sync_stopper", |b| {
+                let stop = SyncStopper::new();
+                b.iter(|| black_box(&stop).check())
+            });
+
+            group.bench("fn_stop", |b| {
+                let stop = FnStop::new(|| false);
+                b.iter(|| black_box(&stop).check())
+            });
+
+            group.bench("boxed_stopper", |b| {
+                let stop = Stopper::new().into_boxed();
+                b.iter(|| black_box(&stop).check())
+            });
+
+            group.bench("dyn_stopper", |b| {
+                let stop = Stopper::new().into_token();
+                b.iter(|| black_box(&stop).check())
+            });
+
+            group.bench("or_stop", |b| {
+                let a = StopSource::new();
+                let b_src = StopSource::new();
+                let stop: OrStop<_, _> = a.as_ref().or(b_src.as_ref());
+                b.iter(|| black_box(&stop).check())
+            });
+
+            group.bench("child_depth_1", |b| {
+                let parent = ChildStopper::new();
+                let stop = parent.child();
+                b.iter(|| black_box(&stop).check())
+            });
+
+            group.bench("child_depth_3", |b| {
+                let g0 = ChildStopper::new();
+                let g1 = g0.child();
+                let g2 = g1.child();
+                let stop = g2.child();
+                b.iter(|| black_box(&stop).check())
+            });
+
+            group.bench("with_timeout", |b| {
+                let source = StopSource::new();
+                let stop: WithTimeout<_> = source.as_ref().with_timeout(Duration::from_secs(3600));
+                b.iter(|| black_box(&stop).check())
+            });
+        });
+
+        // ═══════════════════════════════════════════════════════════
+        // 2. Dispatch: generic vs dyn vs StopToken
+        // ═══════════════════════════════════════════════════════════
+
+        suite.compare("dispatch", |group| {
+            group.config().sort_by_speed(true).cache_firewall(false);
+            group.baseline("stopper_generic");
+
+            group.bench("stopper_generic", |b| {
+                let stop = Stopper::new();
+                b.iter(|| check_generic(black_box(&stop)))
+            });
+
+            group.bench("stopper_dyn", |b| {
+                let stop = Stopper::new();
+                b.iter(|| check_dyn(black_box(&stop)))
+            });
+
+            group.bench("stopper_dynstop", |b| {
+                let stop = Stopper::new().into_token();
+                b.iter(|| black_box(&stop).check())
+            });
+
+            group.bench("stopper_dynstop_as_dyn", |b| {
+                let stop = Stopper::new().into_token();
+                b.iter(|| check_dyn(black_box(&stop) as &dyn Stop))
+            });
+
+            group.bench("unstoppable_generic", |b| {
+                let stop = Unstoppable;
+                b.iter(|| check_generic(black_box(&stop)))
+            });
+
+            group.bench("unstoppable_dyn", |b| {
+                let stop = Unstoppable;
+                b.iter(|| check_dyn(black_box(&stop)))
+            });
+        });
+
+        // ═══════════════════════════════════════════════════════════
+        // 3. Cancelled path (error return)
+        // ═══════════════════════════════════════════════════════════
+
+        suite.compare("check_cancelled", |group| {
+            group.config().sort_by_speed(true).cache_firewall(false);
+            group.baseline("stopper");
+
+            group.bench("stopper", |b| {
+                let stop = Stopper::cancelled();
+                b.iter(|| black_box(&stop).check())
+            });
+
+            group.bench("sync_stopper", |b| {
+                let stop = SyncStopper::cancelled();
+                b.iter(|| black_box(&stop).check())
+            });
+        });
+
+        // ═══════════════════════════════════════════════════════════
+        // 4. Hot loop: impl Stop vs dyn Stop vs StopToken
+        //
+        // Proves that impl Stop inlining is negligible vs dyn dispatch
+        // in realistic loops with work between checks.
+        // ═══════════════════════════════════════════════════════════
+
+        suite.compare("hot_loop_stopper", |group| {
+            group.config().sort_by_speed(true).cache_firewall(false);
+            group.baseline("impl_stop");
+            group.throughput(zenbench::Throughput::Elements(HOT_LOOP_ITERS as u64));
+
+            group.bench("impl_stop", |b| {
+                let stop = Stopper::new();
+                b.iter(|| {
+                    let mut acc = 0usize;
+                    for i in 0..HOT_LOOP_ITERS {
+                        if i % CHECK_INTERVAL == 0 {
+                            let _ = stop.check();
+                        }
+                        acc = acc.wrapping_add(trivial_work(i));
+                    }
+                    black_box(acc)
+                })
+            });
+
+            group.bench("stoptoken", |b| {
+                let stop = Stopper::new().into_token();
+                b.iter(|| {
+                    let mut acc = 0usize;
+                    for i in 0..HOT_LOOP_ITERS {
+                        if i % CHECK_INTERVAL == 0 {
+                            let _ = stop.check();
+                        }
+                        acc = acc.wrapping_add(trivial_work(i));
+                    }
+                    black_box(acc)
+                })
+            });
+
+            group.bench("dyn_may_stop", |b| {
+                let stop = Stopper::new();
+                let stop: &dyn Stop = &stop;
+                let stop = stop.may_stop().then_some(stop);
+                b.iter(|| {
+                    let mut acc = 0usize;
+                    for i in 0..HOT_LOOP_ITERS {
+                        if i % CHECK_INTERVAL == 0 {
+                            let _ = stop.check();
+                        }
+                        acc = acc.wrapping_add(trivial_work(i));
+                    }
+                    black_box(acc)
+                })
+            });
+
+            group.bench("dyn_raw", |b| {
+                let stop = Stopper::new();
+                let stop: &dyn Stop = &stop;
+                b.iter(|| {
+                    let mut acc = 0usize;
+                    for i in 0..HOT_LOOP_ITERS {
+                        if i % CHECK_INTERVAL == 0 {
+                            let _ = stop.check();
+                        }
+                        acc = acc.wrapping_add(trivial_work(i));
+                    }
+                    black_box(acc)
+                })
+            });
+        });
+
+        suite.compare("hot_loop_unstoppable", |group| {
+            group.config().sort_by_speed(true).cache_firewall(false);
+            group.baseline("impl_stop");
+            group.throughput(zenbench::Throughput::Elements(HOT_LOOP_ITERS as u64));
+
+            group.bench("impl_stop", |b| {
+                let stop = Unstoppable;
+                b.iter(|| {
+                    let mut acc = 0usize;
+                    for i in 0..HOT_LOOP_ITERS {
+                        if i % CHECK_INTERVAL == 0 {
+                            let _ = stop.check();
+                        }
+                        acc = acc.wrapping_add(trivial_work(i));
+                    }
+                    black_box(acc)
+                })
+            });
+
+            group.bench("stoptoken", |b| {
+                let stop = Unstoppable.into_token();
+                b.iter(|| {
+                    let mut acc = 0usize;
+                    for i in 0..HOT_LOOP_ITERS {
+                        if i % CHECK_INTERVAL == 0 {
+                            let _ = stop.check();
+                        }
+                        acc = acc.wrapping_add(trivial_work(i));
+                    }
+                    black_box(acc)
+                })
+            });
+
+            group.bench("dyn_may_stop", |b| {
+                let stop = Unstoppable;
+                let stop: &dyn Stop = &stop;
+                let stop = stop.may_stop().then_some(stop);
+                b.iter(|| {
+                    let mut acc = 0usize;
+                    for i in 0..HOT_LOOP_ITERS {
+                        if i % CHECK_INTERVAL == 0 {
+                            let _ = stop.check();
+                        }
+                        acc = acc.wrapping_add(trivial_work(i));
+                    }
+                    black_box(acc)
+                })
+            });
+
+            group.bench("dyn_raw", |b| {
+                let stop = Unstoppable;
+                let stop: &dyn Stop = &stop;
+                b.iter(|| {
+                    let mut acc = 0usize;
+                    for i in 0..HOT_LOOP_ITERS {
+                        if i % CHECK_INTERVAL == 0 {
+                            let _ = stop.check();
+                        }
+                        acc = acc.wrapping_add(trivial_work(i));
+                    }
+                    black_box(acc)
+                })
+            });
+        });
+    });
+
+    if let Err(e) = result.save("stop_check_results.json") {
+        eprintln!("Failed to save results: {e}");
+    }
+}

--- a/crates/almost-enough/src/time/debounced.rs
+++ b/crates/almost-enough/src/time/debounced.rs
@@ -237,7 +237,7 @@ impl<T: Stop> Stop for DebouncedTimeout<T> {
         let skip = self.skip_mod.load(Relaxed);
 
         // Hot path: skip the clock read.
-        if !count.is_multiple_of(skip) {
+        if count % skip != 0 {
             return Ok(());
         }
 
@@ -258,7 +258,7 @@ impl<T: Stop> Stop for DebouncedTimeout<T> {
         let count = self.call_count.fetch_add(1, Relaxed).wrapping_add(1);
         let skip = self.skip_mod.load(Relaxed);
 
-        if !count.is_multiple_of(skip) {
+        if count % skip != 0 {
             return false;
         }
 

--- a/crates/enough-ffi/src/lib.rs
+++ b/crates/enough-ffi/src/lib.rs
@@ -424,6 +424,16 @@ pub unsafe extern "C" fn enough_token_destroy(token: *mut FfiCancellationToken) 
 mod tests {
     use super::*;
 
+    /// Wrapper to send raw pointers across threads in tests.
+    /// Sound because `FfiCancellationToken` is backed by `Arc` and is thread-safe.
+    struct SendPtr(*mut FfiCancellationToken);
+    unsafe impl Send for SendPtr {}
+    impl SendPtr {
+        fn ptr(self) -> *mut FfiCancellationToken {
+            self.0
+        }
+    }
+
     #[test]
     fn source_create_cancel_destroy() {
         unsafe {
@@ -641,20 +651,19 @@ mod tests {
             let cancelled_count = Arc::new(AtomicUsize::new(0));
             let check_count = Arc::new(AtomicUsize::new(0));
 
-            // Create tokens upfront and convert to addresses
             let tokens: Vec<_> = (0..10)
-                .map(|_| enough_token_create(source) as usize)
+                .map(|_| SendPtr(enough_token_create(source)))
                 .collect();
 
             // Spawn multiple threads that check cancellation
             let handles: Vec<_> = tokens
                 .into_iter()
-                .map(|token_addr| {
+                .map(|ptr| {
                     let cancelled_count = Arc::clone(&cancelled_count);
                     let check_count = Arc::clone(&check_count);
 
                     thread::spawn(move || {
-                        let token = token_addr as *mut FfiCancellationToken;
+                        let token = ptr.ptr();
                         let view = FfiCancellationToken::from_ptr(token);
                         for _ in 0..10000 {
                             check_count.fetch_add(1, Ordering::Relaxed);
@@ -693,10 +702,10 @@ mod tests {
             let source = enough_cancellation_create();
             let token = enough_token_create(source);
 
-            // Send token to another thread
-            let token_addr = token as usize;
+            // Send token to another thread via SendPtr (preserves provenance)
+            let send_token = SendPtr(token);
             let handle = thread::spawn(move || {
-                let token = token_addr as *const FfiCancellationToken;
+                let token = send_token.ptr();
                 let view = FfiCancellationToken::from_ptr(token);
 
                 // Spin until cancelled

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,31 @@
+[graph]
+targets = []
+all-features = true
+exclude = [
+    "test-basic",
+    "test-atomic",
+    "test-timeout",
+    "test-child",
+    "test-rayon",
+    "test-tokio",
+    "test-ffi",
+    "test-codec-mock",
+    "test-ergonomics",
+    "test-or-do-this",
+]
+
+[advisories]
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+
+[licenses]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Unicode-3.0",
+]
+confidence-threshold = 0.8
+
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"


### PR DESCRIPTION
## Summary

- Replace `u64::is_multiple_of()` (stabilized in 1.87) with `count % skip != 0` in `DebouncedTimeout`
- Lower workspace `rust-version` to 1.85 (edition 2024 floor)
- Update CI matrix to test MSRV 1.85

`enough` already compiled on 1.85; the `is_multiple_of` call in `almost-enough` was the only blocker.

## Test plan

- [x] `cargo test --workspace` passes locally (326 tests)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [ ] CI passes on all platforms