### PR TITLE
docs(enough): show how to construct + flip a real cancellation token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- README: a complete construct-and-cancel example using
+  `almost_enough::Stopper` — the producer side (how to make and flip a real
+  cancellation token) was previously undocumented.
 - Versioned public-API surface snapshots at `docs/public-api/<crate>.txt`
   for `enough`, `almost-enough`, `enough-tokio`, and `enough-ffi`,
   regenerated on every `cargo test` via

--- a/README.md
+++ b/README.md
@@ -39,11 +39,54 @@ let data = [1u8; 4096];
 assert_eq!(sum_chunks(&data, Unstoppable).unwrap(), 4096);
 ```
 
-To actually cancel something, you need a concrete stop type — a `Stopper` you can
-flip from another thread, a timeout, a tree of child cancellations. Those live in
-[`almost-enough`](https://docs.rs/almost-enough); this crate is just the trait
-plus `Unstoppable`, so library authors can accept cancellation without pulling in
-allocation or any dependencies.
+`enough` gives a library the *consumer* side: accept `impl Stop`, call
+`check()`, optimize away `Unstoppable`. It deliberately ships **no constructible
+token** — no allocation, no dependencies. To *produce* and *flip* a real
+cancellation flag, an application reaches for `Stopper` in the sibling
+[`almost-enough`](https://crates.io/crates/almost-enough) crate.
+
+## Actually Cancel Something
+
+`Stopper` is an `Arc`-backed flag: clone it to share one flag across threads, and
+call `.cancel()` on any clone to flip them all. It implements `Stop`, so the same
+function above accepts it directly.
+
+```toml
+[dependencies]
+enough = "0.4.4"
+almost-enough = "0.4.4"  # the constructible Stopper lives here
+```
+
+```rust
+use std::thread;
+use std::time::Duration;
+use almost_enough::Stopper; // implements `enough::Stop`
+
+let stop = Stopper::new();
+let worker_stop = stop.clone(); // same flag, shared across threads
+
+let worker = thread::spawn(move || {
+    let mut ticks = 0u64;
+    // Loop until another thread flips the flag.
+    while worker_stop.check().is_ok() {
+        ticks += 1;
+        thread::sleep(Duration::from_millis(1));
+    }
+    ticks // returns once cancelled
+});
+
+// ...let it run, then cancel from this side.
+thread::sleep(Duration::from_millis(20));
+stop.cancel(); // flips every clone; check() now returns Err(StopReason::Cancelled)
+
+let ticks = worker.join().unwrap();
+assert!(ticks > 0); // it ran, then stopped when we cancelled
+```
+
+`stop.cancel()` is the flip method (idempotent), and `Stopper::cancelled()`
+constructs one that is already tripped. `almost-enough` also provides timeouts,
+parent/child cancellation trees, and `StopToken` — see its
+[docs](https://docs.rs/almost-enough).
 
 ## The Trait
 


### PR DESCRIPTION
The README documents the **consumer** side of cancellation flawlessly — the `Stop` trait, `check()`, and the `Unstoppable` no-op — but never showed the **producer** side: how to construct a real, cancellable token and the method to flip it. The constructible `Stopper` lives in the sibling `almost-enough` crate, which the README named but never demonstrated.

An insulated external-developer test (given only this README) hit exactly this wall and guessed `.stop()` for the flip method. The real method is `.cancel()`. This documentation gap was the **root cause** of cancellation-token confusion that rippled across several downstream crates.

## What this adds

A self-contained "Actually Cancel Something" section with a complete, copy-pasteable example:
- the `almost-enough = "0.4.4"` dep line (since the constructible token lives there),
- `Stopper::new()`, clone a handle to a worker thread, the worker loops on `check()`,
- cancel from the other side via the real `.cancel()` method, and assert it stopped.

All symbols verified against the published `enough` 0.4.4 + `almost-enough` 0.4.4 source, and the example was compiled and run end-to-end against the real crates before committing. The excellent existing consumer-side docs are untouched — this only adds the missing producer-side example and clarifies the `enough` (accept `Stop`) vs `almost-enough` (construct `Stopper`) split.