### PR TITLE
docs: enough-tokio consumer deps + enough-ffi from_ptr type/null/thread-safety contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@
 - README: a complete construct-and-cancel example using
   `almost_enough::Stopper` — the producer side (how to make and flip a real
   cancellation token) was previously undocumented.
+
+### Fixed
+
+- `enough-tokio` README: added the consumer `[dependencies]` block a copy-paster
+  needs — `enough` (not re-exported, required for the `Stop` trait), `tokio-util`
+  (provides `CancellationToken`), and the `tokio` features the examples use
+  (`rt-multi-thread`/`macros`/`time`); previously only the crate's own dev-dep
+  manifest was shown.
+- `enough-ffi` README: reconciled `FfiCancellationToken::from_ptr` — documented its
+  real signature and that it returns a `FfiCancellationTokenView` (not a
+  `FfiCancellationToken`), is `unsafe`, treats a null pointer as never-cancelled,
+  and is safe to poll from one thread while another cancels. Added a pure-C
+  end-to-end snippet and a note that the `enough_*` symbols export only via a
+  downstream `cdylib`/`staticlib`.
 - Versioned public-API surface snapshots at `docs/public-api/<crate>.txt`
   for `enough`, `almost-enough`, `enough-tokio`, and `enough-ffi`,
   regenerated on every `cargo test` via

--- a/crates/enough-ffi/README.md
+++ b/crates/enough-ffi/README.md
@@ -37,22 +37,78 @@ bool  enough_token_is_cancelled(void* token);
 void  enough_token_destroy(void* token);
 ```
 
+These eight `enough_*` symbols are exported with `#[unsafe(no_mangle)] extern "C"`, but
+this crate has **no `[lib] crate-type`** of its own — it builds as an `rlib`. The symbols
+become linkable C entry points only when a **downstream crate that depends on `enough-ffi`
+builds a `cdylib` or `staticlib`** (e.g. `crate-type = ["cdylib"]` in that crate's
+`Cargo.toml`). Linking `enough-ffi` alone does not produce a `.so`/`.dll`/`.a`.
+
+### Pure-C end-to-end example
+
+Source on one thread, cancellation from another, all through the C ABI. Compile against
+the `cdylib` your downstream crate produces (here called `mylib`):
+
+```c
+#include <stddef.h>
+#include <stdio.h>
+#include <pthread.h>
+#include <unistd.h>
+
+// Exported from your cdylib (which re-exports enough-ffi's symbols).
+extern void* enough_cancellation_create(void);
+extern void  enough_cancellation_cancel(void* source);
+extern void  enough_cancellation_destroy(void* source);
+extern void* enough_token_create(void* source);
+extern void  enough_token_destroy(void* token);
+
+// A Rust FFI function in your cdylib that takes the token pointer and polls it
+// (it builds an FfiCancellationTokenView internally via from_ptr).
+extern int my_operation(const unsigned char* data, size_t len, const void* token);
+
+static void* canceller(void* source) {
+    sleep(1);                           // let the worker start polling
+    enough_cancellation_cancel(source); // cancel from a different thread — sound
+    return NULL;
+}
+
+int main(void) {
+    void* source = enough_cancellation_create();
+    void* token  = enough_token_create(source);
+
+    pthread_t t;
+    pthread_create(&t, NULL, canceller, source);
+
+    unsigned char data[100000] = {0};
+    int rc = my_operation(data, sizeof data, token); // returns -1 once cancelled
+    printf("my_operation -> %d\n", rc);
+
+    pthread_join(t, NULL);
+    enough_token_destroy(token);         // destroy token first,
+    enough_cancellation_destroy(source); // then source (order is not required — both safe)
+    return 0;
+}
+```
+
 ### Rust FFI Functions
 
-When writing Rust FFI functions that receive a token pointer:
+When writing Rust FFI functions that receive a token pointer, turn the raw pointer
+into a `FfiCancellationTokenView` and use it as `impl Stop`:
 
 ```rust
-use enough_ffi::FfiCancellationToken;
+use enough_ffi::{FfiCancellationToken, FfiCancellationTokenView};
 use enough::Stop;
 
-#[no_mangle]
+// `#[no_mangle]` requires the `unsafe(...)` wrapper on edition 2024.
+#[unsafe(no_mangle)]
 pub extern "C" fn my_operation(
     data: *const u8,
     len: usize,
     token: *const FfiCancellationToken,
 ) -> i32 {
-    // Create a non-owning view from the pointer
-    let stop = unsafe { FfiCancellationToken::from_ptr(token) };
+    // `from_ptr` is an associated fn on `FfiCancellationToken` that RETURNS a
+    // `FfiCancellationTokenView` (a non-owning, Copy view) — it does NOT return a
+    // `FfiCancellationToken`. It is `unsafe`: see the contract below.
+    let stop: FfiCancellationTokenView = unsafe { FfiCancellationToken::from_ptr(token) };
 
     // Use with any library that accepts impl Stop
     for i in 0..len {
@@ -64,6 +120,37 @@ pub extern "C" fn my_operation(
     0
 }
 ```
+
+**`from_ptr` signature** (associated fn on `FfiCancellationToken`):
+
+```rust
+pub unsafe fn from_ptr(ptr: *const FfiCancellationToken) -> FfiCancellationTokenView
+```
+
+- **It returns a `FfiCancellationTokenView`, not a `FfiCancellationToken`.** The view
+  is the type listed below as "non-owning view for Rust FFI functions". The owning
+  `FfiCancellationToken` (created by `enough_token_create`) is what the C side holds and
+  passes by pointer; Rust borrows it as a view.
+- **It is `unsafe`** — you assert the safety contract that follows.
+
+#### Null-pointer and lifetime contract
+
+- **`from_ptr(null)` is allowed and never cancels.** A view built from a null pointer
+  reports `should_stop() == false` and `check() == Ok(())` — i.e. it behaves like a
+  "never cancelled" token (equivalent to `FfiCancellationTokenView::never()`). No
+  dereference happens on the null path, so it cannot fault.
+- **Lifetime:** if `ptr` is non-null it must point to a valid `FfiCancellationToken`,
+  and that token must stay alive (not be passed to `enough_token_destroy`) for as long
+  as the view — and any copy of it — is used. The view borrows; it does not bump the
+  `Arc` refcount or take ownership.
+
+#### Thread safety
+
+`FfiCancellationTokenView` is `Send + Sync` and the underlying state is an atomic behind
+an `Arc`. **It is sound for one thread to call the cancel function while another thread is
+running `should_stop()` / `check()` on a view of the same token** — that is exactly the
+intended usage (a C callback cancels the source while a Rust worker polls the token). No
+external locking is required.
 
 ### C# Integration
 
@@ -132,8 +219,8 @@ function withCancellation(signal, operation) {
 | Type | Description |
 |------|-------------|
 | `FfiCancellationSource` | Owns cancellation state, can trigger cancellation |
-| `FfiCancellationToken` | Holds reference to state, can check cancellation |
-| `FfiCancellationTokenView` | Non-owning view for Rust FFI functions |
+| `FfiCancellationToken` | Owns a reference to the state; this is what crosses FFI by pointer. Can check cancellation; provides the `from_ptr` constructor |
+| `FfiCancellationTokenView` | Non-owning `Copy` view for Rust FFI functions. **This is the return type of `FfiCancellationToken::from_ptr`** |
 
 ## License
 

--- a/crates/enough-tokio/README.md
+++ b/crates/enough-tokio/README.md
@@ -18,6 +18,22 @@ This crate bridges tokio's `CancellationToken` with the `Stop` trait, allowing y
 
 ## Quick Start
 
+Add the direct dependencies a consumer needs. `enough-tokio` re-exports neither the
+`Stop` trait (you `use enough::Stop` directly) nor `CancellationToken` (it lives in
+`tokio-util`), so all four are direct dependencies of your crate:
+
+```toml
+[dependencies]
+enough-tokio = "0.5"
+# enough-tokio does NOT re-export `Stop`; add `enough` to call `stop.should_stop()` / `.check()`
+enough = "0.5"
+# `CancellationToken` comes from tokio-util (enough-tokio re-exports nothing from it)
+tokio-util = "0.7"
+# tokio is only a *dev*-dependency of enough-tokio; a consumer adds it explicitly.
+# The runtime + `#[tokio::main]` + `spawn_blocking` + `sleep` used below need these features:
+tokio = { version = "1.43", features = ["rt-multi-thread", "macros", "time"] }
+```
+
 ```rust
 use enough_tokio::TokioStop;
 use enough::Stop;


### PR DESCRIPTION
Found via insulated "external developer" usability tests of the **published** `enough-tokio` 0.5.0 and `enough-ffi` 0.4.0 READMEs. Both crates live in this repo, so both README gaps are fixed in one PR. All claims verified against `crates/*/src/lib.rs`.

## enough-tokio
The Quick Start only showed the crate's *own* manifest (tokio as a dev-dep), so a consumer copy-pasting the examples couldn't build. Added a consumer `[dependencies]` block:
- `enough` — **not re-exported** (`grep` confirms no `pub use enough`/`Stop` in `enough-tokio/src/lib.rs`); required because the examples do `use enough::Stop`.
- `tokio-util` `0.7` — provides `CancellationToken` (a real direct dep of enough-tokio; nothing re-exported from it).
- `tokio` with `["rt-multi-thread", "macros", "time"]` — tokio is only a *dev*-dependency of enough-tokio, so a consumer must add it; the features cover the `#[tokio::main]` + `spawn_blocking` + `sleep` shown. (No `ctrl_c`/`signal` is used in the crate, so no `signal` feature is needed.)

## enough-ffi
1. **`from_ptr` type/return reconciliation (the worst gap).** The Rust example called `FfiCancellationToken::from_ptr(...)` while the Types table listed `FfiCancellationTokenView` separately, with no statement of how they relate. Verified: `pub unsafe fn from_ptr(ptr: *const FfiCancellationToken) -> FfiCancellationTokenView` is an associated fn on `FfiCancellationToken` that **returns a `FfiCancellationTokenView`, not a `FfiCancellationToken`**. The example, a signature block, and the Types table now all say so.
2. **Null + lifetime contract.** `from_ptr(null)` is allowed and behaves as never-cancelled (`should_stop()==false`, `check()==Ok`); non-null must point to a live `FfiCancellationToken` that outlives the view (and its copies) — the view borrows, it does not bump the `Arc`.
3. **Thread safety.** Documented that it is sound to call the cancel function on one thread while another polls `should_stop()`/`check()` on a view of the same token (the View is `Send + Sync`, backed by `Arc<AtomicBool>`).
4. **Pure-C end-to-end snippet + symbol export.** Added a create→token→Rust-call→cancel-from-another-thread→destroy C example, and noted the eight `enough_*` `#[unsafe(no_mangle)] extern "C"` symbols export only when a downstream crate builds a `cdylib`/`staticlib` (enough-ffi itself has no `crate-type` → rlib).

CHANGELOG `[Unreleased]` updated. Diff is README + CHANGELOG only.