### PR TITLE
feat(error): re-add core::error::Error for StopReason (0.4.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Added
 
+- `impl core::error::Error for StopReason` — re-added (it was removed in 0.4.0).
+  `StopReason` stays a leaf cause (`source()` is `None`); the impl lets a
+  consumer expose a wrapped `StopReason` through its own error's `source()`
+  chain so a generic caller can classify cancellation/timeout by downcast
+  (e.g. `zencodec::CodecErrorExt::cancelled` / `stop_reason`) without naming
+  the concrete error enum. `core::error::Error` (Rust 1.81+, MSRV here is 1.85)
+  is available in `no_std` with no feature flag, so the `no_std` surface is
+  unchanged. Additive — re-adding the impl is non-breaking.
 - README: a complete construct-and-cancel example using
   `almost_enough::Stopper` — the producer side (how to make and flip a real
   cancellation token) was previously undocumented.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 exclude = ["apidoc"]
 
 [workspace.package]
-version = "0.4.4"
+version = "0.4.5"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"
@@ -31,8 +31,8 @@ keywords = ["cancellation", "cooperative", "async", "ffi", "no_std"]
 categories = ["concurrency", "no-std", "rust-patterns"]
 
 [workspace.dependencies]
-enough = { version = "0.4.4", path = "crates/enough", default-features = false }
-almost-enough = { version = "0.4.4", path = "crates/almost-enough", features = ["std"] }
+enough = { version = "0.4.5", path = "crates/enough", default-features = false }
+almost-enough = { version = "0.4.5", path = "crates/almost-enough", features = ["std"] }
 zenbench = "0.1.6"
 # enough-tokio and enough-ffi have independent versioning
 enough-tokio = { path = "crates/enough-tokio" }

--- a/crates/enough/src/reason.rs
+++ b/crates/enough/src/reason.rs
@@ -74,6 +74,18 @@ impl fmt::Display for StopReason {
     }
 }
 
+// `core::error::Error` (stable since Rust 1.81; this crate's MSRV is 1.85) is
+// available in `no_std` with no feature flag, so implementing it costs nothing
+// on the `no_std` feature surface. `StopReason` is a leaf — it has no inner
+// cause, so `source()` keeps the default `None`. The value of the impl is that
+// `StopReason` can now appear as a *findable cause* in another error type's
+// `source()` chain: a consumer that wraps it (`impl From<StopReason> for
+// MyError`) can expose it via `#[source]`/`#[from]`, and a generic caller can
+// recover it with a downcast walk (e.g. zencodec's `CodecErrorExt::cancelled`)
+// without naming the concrete error enum. (Re-added after 0.4.0's removal,
+// which predated the classification use case and targeted `std::error::Error`.)
+impl core::error::Error for StopReason {}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -84,6 +96,19 @@ mod tests {
         use alloc::format;
         assert_eq!(format!("{}", StopReason::Cancelled), "operation cancelled");
         assert_eq!(format!("{}", StopReason::TimedOut), "operation timed out");
+    }
+
+    #[test]
+    fn stop_reason_is_error_and_downcastable() {
+        // The point of the re-added impl: StopReason can be a findable cause in
+        // another error's source() chain and be recovered by a downcast walk.
+        let r = StopReason::Cancelled;
+        let dyn_err: &(dyn core::error::Error + 'static) = &r;
+        assert!(dyn_err.source().is_none(), "StopReason is a leaf cause");
+        assert_eq!(
+            dyn_err.downcast_ref::<StopReason>(),
+            Some(&StopReason::Cancelled)
+        );
     }
 
     #[test]

--- a/docs/public-api/enough.txt
+++ b/docs/public-api/enough.txt
@@ -15,7 +15,7 @@
 #   free functions                              3
 #   inherent methods                            6
 #   enum variants                               2
-#   trait roster entries (type × trait)        18
+#   trait roster entries (type × trait)        19
 #   auto-trait-complete types                   2
 #
 # per-module pub lines:
@@ -44,7 +44,7 @@ pub type Never = Unstoppable
 
 &T: Stop
 &mut T: Stop
-StopReason: Clone, Copy, Debug, Display, Eq, Hash, PartialEq
+StopReason: Clone, Copy, Debug, Display, Eq, Error, Hash, PartialEq
 Unstoppable: Clone, Copy, Debug, Default, Eq, Hash, PartialEq, Stop
 core::option::Option<T>: Stop
 


### PR DESCRIPTION
## Summary

Re-adds `impl core::error::Error for StopReason`, removed in 0.4.0 (`bd704e0`). This is the **root fix** enabling generic cancellation classification in zencodec ([imazen/zencodec#99](https://github.com/imazen/zencodec/issues/99)).

## Why re-add it (every 0.4.0 removal reason is now moot or outweighed)

The 0.4.0 commit gave three reasons; here's where each stands:

- *"simplifies feature flag surface for no_std"* — that was **`std::error::Error`** at MSRV 1.71, before `core::error::Error` existed. `core::error::Error` (stable **Rust 1.81**) lives in `core` with **no feature flag**, and this crate's MSRV is **1.85**. So the impl is unconditionally `no_std`-clean — the original concern is gone.
- *"added no value beyond Display+Debug+From"* — it now adds exactly the value the downstream needs: a wrapped `StopReason` becomes a **findable cause** in a consumer error's `source()` chain, so a generic caller can classify cancel/timeout by downcast without naming the concrete error enum.
- *"no inner cause, source() always None"* — still true and fine: `StopReason` stays a **leaf** (`source()` is `None`). We want it to *be* a findable cause, not to *have* one.

And the 0.4.0 message itself noted: *"Adding it back later would be non-breaking if needed."* This is that moment.

## Changes

- `impl core::error::Error for StopReason {}` (+ a test asserting it's `dyn Error` and downcastable; `source()` stays `None`).
- Workspace version `0.4.4` → `0.4.5` (additive / non-breaking).
- CHANGELOG entry under `[Unreleased]`.
- Regenerated `docs/public-api/enough.txt` (roster `18` → `19`; `StopReason: … Error …`).

## Verification

`cargo test -p enough` green (incl. the new downcast test); `cargo fmt --check` + `cargo clippy` clean; public-API snapshot current (`just api-doc`). MSRV 1.85 ≥ 1.81 covers `core::error::Error`; `no_std`/wasm unaffected (no feature flag).

## Status

Draft — paired with the zencodec #99 change (which depends on this via a temporary git patch until 0.4.5 publishes). Not yet released to crates.io.